### PR TITLE
feat(parser): raise YAML 1.2 compliance to 97.93%

### DIFF
--- a/.changeset/raise-yaml-compliance-97-93.md
+++ b/.changeset/raise-yaml-compliance-97-93.md
@@ -1,0 +1,54 @@
+---
+"yaml-effect": minor
+---
+
+## Features
+
+### YAML 1.2 spec compliance raised to 97.93%
+
+Round-trip canonical output now preserves source representation in
+several places that previously lost information.
+
+- Block scalar chomp indicators (keep, strip, clip) are tracked on the
+  scalar AST node so a keep-chomp block scalar parses, stringifies, and
+  re-parses without losing trailing-newline semantics.
+- Numeric scalars expose the source representation on a new optional
+  field so non-canonical numeric formats survive a parse-stringify round
+  trip. Hex literals like 0xFFEEBB stay hex, and decimals with trailing
+  zeros like 450.00 keep their precision.
+- Tag and anchor placement on block collections now honours newlines
+  between the marker and the inner key. A tag that crosses a newline
+  attaches to the collection rather than to the first key inside it.
+- Document-level outer/inner metadata is split when a doc starts with
+  metadata on one line and a tagged or anchored first key on the next.
+  Both pieces of metadata are now preserved instead of the inner one
+  silently overwriting the outer one.
+- The stringifier emits an explicit document-end marker after a document
+  whose final scalar uses keep-chomp, so the open-ended scalar has an
+  unambiguous terminator on output.
+
+### New optional fields on YamlScalar
+
+YamlScalar gains two optional fields that callers can read but are not
+required to construct.
+
+- chomp: literal "strip" / "clip" / "keep" populated when the source
+  uses a block scalar header. Surfaces the original chomp indicator for
+  consumers that need to render canonical YAML or build tools that
+  depend on byte-for-byte fidelity.
+- raw: the source representation string, populated only when the
+  resolved value is non-string and the source form differs from the
+  default JS rendering. Useful for IDEs and formatters that want to
+  preserve the user's chosen numeric notation.
+
+## Bug Fixes
+
+- Fixed a regression where a keep-chomp block scalar with newline-only
+  content was emitted as a double-quoted scalar, breaking round-trip.
+- Fixed canonical output for sequences whose tagged item is a block
+  map: the tag now sits on its own line above the indented map keys
+  rather than inline with the first key.
+- Fixed canonical output for explicit-key entries whose key is a
+  collection with anchor-only metadata on its first line. Continuation
+  lines now sit at the same indent as the question-mark marker rather
+  than indented one level deeper.

--- a/.claude/design/yaml-effect/compliance-testing.md
+++ b/.claude/design/yaml-effect/compliance-testing.md
@@ -413,17 +413,14 @@ into per-category issues (#15, #16).
 | #15 | Parser rejects valid YAML | **Resolved** (0 remaining XFAIL "rejects valid") |
 | #16 | Parser accepts invalid YAML | Open (23 XFAIL "accepts invalid") |
 
-Current compliance: 2348/2409 raw assertions passing (97.47%), 1188
+Current compliance: 2374/2424 raw assertions passing (97.93%), 1188
 filtered assertions passing, 23 XFAIL (all "accepts invalid"), 0 JSON
-comparison failures, 0 roundtrip failures, ~38 SKIP_ASSERTIONS entries
+comparison failures, 0 roundtrip failures, ~28 SKIP_ASSERTIONS entries
 (output only). Use `pnpm run test:compliance-raw` to see unfiltered
 results.
 
 Remaining canonical-output gaps cluster into a few categories:
 
-- **Tag-on-block-collection inline placement** (6JWB, 735Y, C4HZ) -- tags
-  applied to block-style maps/sequences need inline placement on the
-  introducing line rather than a leading line of their own.
 - **Explicit `?` syntax for complex keys** (5WE3, 6SLA, M5DY, Q9WF, X38W) --
   emitting `? key\n: value` for non-scalar or multi-line keys in canonical
   block form.
@@ -584,6 +581,77 @@ values in mappings).
 Five canonical-output tests removed from `SKIP_ASSERTIONS` in
 `__test__/utils/yaml-test-suite-skip-map.ts`: 26DV, 7BMT, FH7J, PW8X,
 U3XV.
+
+### Key Compliance Improvements (chomp preservation + numeric raw + meta split)
+
+The jump from 97.47% to 97.93% raw compliance (2374/2424 assertions,
++26 assertions, +10 canonical-output tests previously skipped) came
+from preserving block-scalar chomp metadata, preserving non-canonical
+numeric source representations, and a document-level outer/inner
+metadata split that mirrors the existing block-map and block-seq
+splits.
+
+The 10 newly-passing canonical-output tests removed from
+`SKIP_ASSERTIONS` in `__test__/utils/yaml-test-suite-skip-map.ts`:
+F8F9, JEF9/00, JEF9/01, JEF9/02, 6JWB, 735Y, C4HZ, UGM3, 9KAX, 6BFJ.
+
+Categories of fixes:
+
+- **Chomp preservation on `YamlScalar`** -- new optional fields
+  `chomp: "strip" | "clip" | "keep"` and `raw: string` on
+  `YamlScalar` (`src/schemas/YamlAstNodes.ts`). The composer's
+  `getBlockChomp()` helper extracts the chomp indicator from the
+  block-scalar header; `makeScalar()` stores it on the resulting node.
+  `stripNodeComments()` and `normalizeNodeTags()` propagate `chomp`
+  and `raw` when constructing replacement nodes so transformations
+  do not lose round-trip metadata.
+- **Value-driven chomp computation in `renderBlockLiteral`**
+  (`src/utils/stringify.ts`) -- chomp is computed primarily from the
+  value's trailing-newline structure (`+` for `\n\n`, `-` for no
+  trailing `\n`, empty/clip for one trailing `\n`). The new
+  `explicitChomp` parameter (sourced from `node.chomp` and routed
+  through `renderString`) reserves `+` for newline-only values when
+  the original chomp was `"keep"`, so an empty `|+` literal
+  round-trips. The explicit indent indicator emission was also
+  refined: for newline-only bodies the indicator is emitted only
+  under keep-chomp.
+- **Keep-chomp `...` document terminator** -- new `endsWithKeepChomp`
+  helper detects when the rendered output ends with `|+` or `>+`. In
+  canonical mode, `stringifyDocument()` emits an explicit `...\n`
+  even when `doc.hasDocumentEnd` is false, because keep-chomp
+  consumes any trailing blanks up to the next document marker --
+  without `...` the reader cannot tell where the open-ended scalar
+  ends. (Resolves F8F9, JEF9/00-02, 9KAX, 6BFJ.)
+- **Numeric raw preservation** -- `makeScalar()` populates `raw` for
+  plain scalars whose resolved value is a number and whose source
+  spelling differs from `String(value)`. The decision is made by
+  `shouldPreserveRaw(rawValue, value)`. The plain-scalar path inside
+  `flattenBlockMapChildren()` (which builds `YamlScalar` directly
+  for synthesized block-map keys/values) also populates `raw`.
+  `stringifyScalarNodeLines()` prefers `node.raw` over
+  `renderNumber(value)` so non-canonical formats (hex `0xFFEEBB`,
+  octal, trailing zeros like `450.00`, leading `+`) survive
+  round-trip. (Resolves UGM3 and several hex/octal canonical-output
+  variants.)
+- **Document-level outer/inner meta split in `composeDocument`** --
+  parallel to the existing splits in `flattenBlockMapChildren` and
+  `composeBlockSeq`. New `outerMeta` slot plus `sawNewlineSinceMeta`
+  flag and `commitMetaAcrossNewline()` helper. When a tag/anchor at
+  document level is followed by a newline and then more meta, the
+  prior meta is committed to `outerMeta` (it belonged to the outer
+  container). All six content-producing root paths (block-map,
+  block-seq, flow-map, flow-seq, scalar-root, multi-line plain
+  scalar) consult both slots. The flow-collection-as-key path
+  splits outer (root map) vs inner (flow collection key) meta.
+  (Resolves 6JWB, 735Y, C4HZ -- "tag-on-block-collection inline
+  placement" -- by ensuring the tag attaches to the outer
+  collection when separated by a newline, then naturally renders
+  inline on the introducing line.)
+- **Newline-aware tag/anchor split in `composeBlockSeq`** -- new
+  `sawNewlineSincePending` flag. When a `-` entry is followed by a
+  newline, then a flow-scalar-then-block-map (the implicit-map case),
+  pending meta is routed to the outer map (`mapMeta`) rather than
+  the first key. Resets on every meta-consuming code path.
 
 ### Dual Block Scalar Decoders
 

--- a/.claude/design/yaml-effect/parsing.md
+++ b/.claude/design/yaml-effect/parsing.md
@@ -211,6 +211,30 @@ The composer walks CST nodes and produces:
 `hasDocumentStart` is detected by checking for a `whitespace` CST node
 with `source === "---"` among the document's children.
 
+### Scalar Construction (`makeScalar`)
+
+`makeScalar()` builds a `YamlScalar` from a CST scalar node. In addition
+to `value`, `style`, `tag`, `anchor`, and `comment`, it populates two
+optional round-trip metadata fields:
+
+- **`chomp`** -- for block scalars only, computed by `getBlockChomp(node)`.
+  The helper trims leading whitespace from `node.source`, isolates the
+  header line (text before the first newline), and returns `"keep"` if it
+  contains `+`, `"strip"` if it contains `-`, otherwise `"clip"`. Returns
+  `undefined` for non-block scalars. The chomp indicator is required for
+  faithful round-tripping of `|+` headers because the resolved value alone
+  cannot distinguish between "the value happened to end in a newline" and
+  "the source explicitly requested all trailing newlines preserved".
+- **`raw`** -- the source representation when `style === "plain"`,
+  `typeof value !== "string"`, and the source form differs from
+  `String(value)`. The check is performed by `shouldPreserveRaw(rawValue,
+  value)`, which returns `true` only for numbers whose source spelling
+  (hex `0xFFEEBB`, octal, `450.00`, etc.) does not equal `String(value)`.
+  Populated by `makeScalar()` for normal scalar nodes and by the
+  plain-scalar paths inside `flattenBlockMapChildren()` (which constructs
+  `YamlScalar` instances directly when synthesizing block-map keys/values
+  from concatenated `flow-scalar` children).
+
 ### TAG Directive Resolution
 
 The composer processes `%TAG` directives to build a tag handle prefix
@@ -247,11 +271,79 @@ structured key/value sequence. Notable behaviors:
   implicit mapping keys (followed by block-map) skip this check since
   the anchor applies to the map, not the alias.
 
+### Newline-Aware Tag/Anchor Split in `composeBlockSeq`
+
+`composeBlockSeq()` tracks `pendingMeta` (the most-recent uncomsumed
+tag/anchor) plus a `sawNewlineSincePending` flag. The flag is set when
+a `newline` CST child is encountered while `pendingMeta` is non-empty,
+and cleared whenever the meta is consumed. When the next significant
+content is a flow-scalar followed by a block-map (the implicit-map case
+inside a sequence entry, e.g. `- !!map\n  key: value`), the helper
+splits the meta:
+
+- If `sawNewlineSincePending` is true, the pending meta belongs to the
+  outer container (the implicit map). The first key is constructed
+  with no meta, and `composeBlockMap(blockMap, state, key, mapMeta)`
+  receives `mapMeta`.
+- Otherwise, the pending meta attaches to the first key (legacy
+  behavior: `&a key: value` anchors the key, not the map).
+
+Without this split, a tag like `!!map` written above the first key on
+its own line was incorrectly attached to the key (or silently dropped
+when the next anchor overwrote it). The same flag is also reset on
+every other code path that consumes `pendingMeta` (scalar, alias,
+block-map, block-seq, empty-key cases).
+
 ### Flow Collection as Document-Level Key
 
 When `composeDocument()` encounters a `flow-seq` or `flow-map` CST node
 followed by a `block-map` sibling, the flow collection becomes the first
 key of an implicit mapping via `composeBlockMap(blockMap, state, flowNode)`.
+When metadata is present, the `outerMeta` split (described below) routes
+it to the outer block-map; the remaining `meta` attaches to the flow
+collection that becomes the inner first key. Both `flow-map`-as-key and
+`flow-seq`-as-key paths use this split.
+
+### Document-Level Outer/Inner Meta Split (`composeDocument`)
+
+`composeDocument()` maintains two metadata slots:
+
+- `meta` -- the most-recent uncommitted tag/anchor at document level.
+- `outerMeta` -- meta that has crossed a newline boundary and therefore
+  belongs to the outer container (the root collection), not to whatever
+  inner key/scalar it precedes.
+
+A `sawNewlineSinceMeta` flag is set whenever a `newline` CST child is
+seen while `meta` is non-empty. When the next `anchor` or `tag` child
+arrives, the helper `commitMetaAcrossNewline()` moves the existing
+`meta` into `outerMeta` (because that meta crossed a newline) and
+starts a fresh `meta` for the incoming token. Without this commit step,
+a sequence like `&a !!t1\n&b !!t2 key: ...` would silently overwrite
+the first pair when the second arrives.
+
+When the document's root content is finally constructed, all six
+content-producing paths consult both slots:
+
+- **block-map** / **block-seq** / **flow-map** / **flow-seq** as root
+  collection -- combine `outerMeta` and `meta` (both apply to the same
+  collection at root level when there is no inner key).
+- **flow-map** / **flow-seq as key** (followed by a `block-map`
+  sibling) -- when `outerMeta` is set, route it to the outer
+  `composeBlockMap` call as `mapMeta`; route remaining `meta` to the
+  flow collection (the inner first key). When `outerMeta` is empty,
+  combine both into the flow collection's meta.
+- **scalar root** (including the multi-line plain scalar path via
+  `collectMultilinePlainScalar`) -- combine `outerMeta` and `meta` and
+  apply to the scalar.
+- **scalar as block-map key** -- when `outerMeta` is set, it becomes
+  the map meta and `meta` becomes the key meta. When `outerMeta` is
+  empty, the legacy `hasDocStart && hasMeta(meta)` rule still treats
+  `meta` as map-level (otherwise it attaches to the key). The same
+  three-branch resolution is applied to both the `block-map` follow-on
+  case and the flat (`hasValueSepAfter`) case.
+
+After the root content is built, both `meta` and `outerMeta` are
+cleared and `sawNewlineSinceMeta` is reset.
 
 ### Explicit Key `?` in Flow Mappings
 

--- a/.claude/design/yaml-effect/schemas.md
+++ b/.claude/design/yaml-effect/schemas.md
@@ -72,6 +72,18 @@ Tag: `"YamlScalar"`. Fields:
 - `tag?: String` -- explicit YAML tag (e.g., `!!str`)
 - `anchor?: String` -- anchor name
 - `comment?: String` -- trailing/leading comment text
+- `chomp?: Literal("strip", "clip", "keep")` -- block-scalar chomp
+  indicator parsed from the source header (`-` strip, `+` keep, otherwise
+  clip). Populated only for block-literal/block-folded scalars; absent for
+  flow scalars. Used by the stringifier to round-trip `|+` / `|-` headers
+  whose semantics cannot be inferred from the resolved value alone (e.g.
+  newline-only content needs `|+` to preserve a trailing newline).
+- `raw?: String` -- source representation of a numeric scalar when it
+  differs from `String(value)`. Populated for plain scalars whose
+  resolved value is `typeof "number"` and whose source form is
+  non-canonical (hex `0xFFEEBB`, octal `0o755`, trailing zeros `450.00`,
+  etc.). The stringifier prefers `raw` over `renderNumber(value)` so the
+  original textual format survives a parse/stringify round-trip.
 - `offset: Int (>= 0)`, `length: Int (>= 0)`
 
 ### YamlAlias

--- a/.claude/design/yaml-effect/stringify.md
+++ b/.claude/design/yaml-effect/stringify.md
@@ -80,11 +80,33 @@ style over double-quoted to produce cleaner output.
 
 - `renderDoubleQuoted(s)` -- escapes `\`, `"`, `\n`, `\r`, `\t`
 - `renderSingleQuoted(s)` -- escapes `'` as `''`
-- `renderBlockLiteral(s, indent)` -- `|` with auto-chomp detection
-  (`+` for trailing `\n\n`, `-` for no trailing `\n`)
-- `renderBlockFolded(s, indent)` -- `>` with same chomp detection
-- `renderString(s, style, indent)` -- dispatches to the appropriate
-  renderer, falling back to double-quoted for unsafe styles
+- `renderBlockLiteral(s, indent, explicitChomp?)` -- `|` with chomp
+  computed primarily from the value's trailing-newline structure: `+`
+  for values ending in `\n\n`, `-` for values with no trailing `\n`,
+  empty (clip) for exactly one trailing `\n`. The optional
+  `explicitChomp` parameter (sourced from `YamlScalar.chomp`) reserves
+  `+` for newline-only values (`/^\n+$/`) when the original chomp was
+  `"keep"`, so that an empty `|+` literal round-trips correctly. The
+  explicit indent indicator (`|2`, etc.) is emitted when the first
+  content line starts with a space, or when the value starts with empty
+  lines and has actual content; for newline-only values the indicator
+  is emitted only under keep-chomp because the trailing blanks form the
+  entire body and the reader has no other way to detect block
+  indentation.
+- `renderBlockFolded(s, indent)` -- `>` with the same value-driven
+  chomp detection (no `explicitChomp` parameter currently).
+- `renderString(s, style, indent, ignoreType?, canonical?, explicitChomp?)`
+  -- dispatches to the appropriate renderer, falling back to
+  double-quoted for unsafe styles. Threads `explicitChomp` through to
+  `renderBlockLiteral` for both the explicit `block-literal` style
+  branch and the canonical-mode fallback used for plain/single-quoted
+  multi-line content.
+- `endsWithKeepChomp(rendered)` -- scans the rendered output for the
+  most recent `|` or `>` block-scalar header (matching
+  `[|>][1-9]?[+-]?` at end-of-string or before a newline) and returns
+  true if its chomp indicator is `+`. Used by `stringifyDocument()` to
+  decide whether to emit a closing `...` document-end marker (see
+  below).
 
 ### Number Rendering
 
@@ -92,6 +114,13 @@ style over double-quoted to produce cleaner output.
 - `Infinity` -> `.inf`
 - `-Infinity` -> `-.inf`
 - Otherwise `String(n)`
+
+When stringifying a `YamlScalar` whose `value` is a number,
+`stringifyScalarNodeLines()` prefers `node.raw` when set over
+`renderNumber(value)`. This preserves non-canonical source spellings
+that resolve to the same JS number (hex `0xFFEEBB`, octal, trailing
+zeros like `450.00`, leading `+`, etc.) across a parse/stringify
+round-trip.
 
 ## Collection Rendering
 
@@ -151,6 +180,39 @@ reads style metadata from each AST node:
 - **Document start**: `---\n` is emitted when `doc.hasDocumentStart` is
   true. When the root node has a tag, the inline form `--- content` is
   used instead
+- **Document end**: `...\n` is emitted when `doc.hasDocumentEnd` is
+  true. In canonical mode (`forceDefaultStyles`), the terminator is
+  also emitted automatically when `endsWithKeepChomp(result)` reports
+  that the rendered body ends with an open-ended block scalar (`|+` or
+  `>+`). Without the explicit `...`, the reader has no way to know
+  where the open-ended scalar ends, since keep-chomp consumes any
+  trailing blank lines up to the next document marker.
+- **Chomp**: `node.chomp` is threaded through `renderString` to
+  `renderBlockLiteral` so that `|+` / `|-` headers round-trip
+  correctly even when the resolved value alone cannot disambiguate
+  them.
+- **Numeric raw**: `node.raw` is preferred over `renderNumber(value)`
+  when stringifying numeric scalars (see Number Rendering).
+
+`stripNodeComments()` and `normalizeNodeTags()` propagate the new
+`chomp` and `raw` fields when constructing replacement scalar nodes,
+so neither comment-stripping nor tag normalization loses round-trip
+metadata.
+
+### Complex-Key Continuation Indent
+
+`stringifyMapNodeLines()` emits `? key` when a key requires explicit
+syntax (multi-line, non-scalar, etc.). Continuation lines after the
+first are normally indented by `pad` (matching the `?` column). When
+the first line of the key contains only metadata tokens (`&anchor`
+and/or `!tag`, with no value text), the continuation lines are the
+actual collection body and are emitted with **no extra padding** -- they
+sit at the same column as `?`. This produces the compact canonical
+form for keys like `? &a !!map\nkey: value`, where `key: value` is the
+map body, not an indented continuation of the key.
+
+The metadata-only test splits the first line on whitespace and checks
+that every non-empty token starts with `&` or `!`.
 
 ### forceDefaultStyles Option
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,10 +112,19 @@ pnpm run lint:fix:unsafe   # Auto-fix including unsafe transforms
 pnpm run lint:md           # Check markdown with markdownlint
 pnpm run lint:md:fix       # Auto-fix markdown issues
 pnpm run typecheck         # Type-check via Turbo (runs tsgo)
-pnpm run test              # Run all tests
+pnpm run test              # Run unit + filtered compliance tests
 pnpm run test:watch        # Run tests in watch mode
 pnpm run test:coverage     # Run tests with v8 coverage report
+pnpm run test:compliance   # Run filtered yaml-test-suite (uses skip maps)
+pnpm run test:compliance-raw  # Run unfiltered yaml-test-suite (true compliance %)
 ```
+
+When changing parser, composer, or stringifier code, run
+`pnpm run test:compliance-raw` to see the true compliance percentage. If
+filtered tests start failing on `it.fails` (a previously XFAIL test now
+passes), remove that entry from
+`__test__/utils/yaml-test-suite-skip-map.ts`. See
+@.claude/design/yaml-effect/compliance-testing.md for the full workflow.
 
 ### Building
 

--- a/__test__/utils/yaml-test-suite-skip-map.ts
+++ b/__test__/utils/yaml-test-suite-skip-map.ts
@@ -14,6 +14,8 @@
  * Updated: escape sequences (named C0 escapes, canonical unicode), tag normalization, multi-doc join, tagged block scalars.
  * Updated: single-quoted multi-line render, scalar-rooted single-doc canonical, block→DQ for tricky whitespace.
  * Updated: dual-anchor composer fix (outer/inner meta split), empty seq item anchor preservation, anchored empty key sep.
+ * Updated: keep-chomp `...` terminator and chomp preservation, source numeric format preserved (hex, trailing zeros),
+ *          tag-on-block-collection (newline-aware), document-level outer/inner meta split.
  */
 
 /** Tests to skip entirely — not applicable to our implementation. */
@@ -60,22 +62,13 @@ export const SKIP_ASSERTIONS: Record<string, string[]> = {
 	"5T43": ["output"],
 	"5WE3": ["output"],
 	"652Z": ["output"],
-	"6BFJ": ["output"],
-	"6JWB": ["output"],
 	"6M2F": ["output"],
 	"6SLA": ["output"],
 	"6WLZ": ["output"],
-	"735Y": ["output"],
-	"9KAX": ["output"],
 	"9MMW": ["output"],
 	"9MQT/00": ["output"],
 	B3HG: ["output"],
-	C4HZ: ["output"],
 	EXG3: ["output"],
-	F8F9: ["output"],
-	"JEF9/00": ["output"],
-	"JEF9/01": ["output"],
-	"JEF9/02": ["output"],
 	K54U: ["output"],
 	K858: ["output"],
 	KK5P: ["output"],
@@ -87,7 +80,6 @@ export const SKIP_ASSERTIONS: Record<string, string[]> = {
 	Q9WF: ["output"],
 	R4YG: ["output"],
 	T5N4: ["output"],
-	UGM3: ["output"],
 	"VJP3/01": ["output"],
 	WZ62: ["output"],
 	X38W: ["output"],

--- a/docs/ast-navigation.md
+++ b/docs/ast-navigation.md
@@ -257,7 +257,7 @@ A leaf value: string, number, boolean, or null.
 | `anchor` | `string` (optional) | Anchor name for aliasing |
 | `comment` | `string` (optional) | Trailing or leading comment |
 | `chomp` | `"strip"` \| `"clip"` \| `"keep"` (optional) | Block scalar chomping indicator (`-`, default, or `+`) preserved from source |
-| `raw` | `string` (optional) | Original source text, used to round-trip non-canonical numeric formats and block scalar headers |
+| `raw` | `string` (optional) | Source text for plain numeric scalars whose form is non-canonical, e.g. hex literals (`0xFFEEBB`) or decimals with trailing zeros (`450.00`) |
 | `offset` | `number` | Zero-based character offset |
 | `length` | `number` | Character length of the span |
 

--- a/docs/ast-navigation.md
+++ b/docs/ast-navigation.md
@@ -256,8 +256,15 @@ A leaf value: string, number, boolean, or null.
 | `tag` | `string` (optional) | Explicit YAML tag |
 | `anchor` | `string` (optional) | Anchor name for aliasing |
 | `comment` | `string` (optional) | Trailing or leading comment |
+| `chomp` | `"strip"` \| `"clip"` \| `"keep"` (optional) | Block scalar chomping indicator (`-`, default, or `+`) preserved from source |
+| `raw` | `string` (optional) | Original source text, used to round-trip non-canonical numeric formats and block scalar headers |
 | `offset` | `number` | Zero-based character offset |
 | `length` | `number` | Character length of the span |
+
+The `chomp` and `raw` fields are populated by the composer when parsing and
+read by the stringifier to preserve fidelity on round-trip. They are optional
+on construction — manually built `YamlScalar` instances do not need to set
+them.
 
 ### `YamlMap`
 

--- a/src/schemas/YamlAstNodes.ts
+++ b/src/schemas/YamlAstNodes.ts
@@ -46,6 +46,8 @@ export class YamlScalar extends Schema.TaggedClass<YamlScalar>()("YamlScalar", {
 	style: ScalarStyle,
 	anchor: Schema.optional(Schema.String),
 	comment: Schema.optional(Schema.String),
+	chomp: Schema.optional(Schema.Literal("strip", "clip", "keep")),
+	raw: Schema.optional(Schema.String),
 	offset: Schema.Int.pipe(Schema.nonNegative()),
 	length: Schema.Int.pipe(Schema.nonNegative()),
 }) {}

--- a/src/utils/composer.ts
+++ b/src/utils/composer.ts
@@ -1112,9 +1112,15 @@ function makeScalar(cst: CstNode, state: ComposerState, meta?: NodeMeta): YamlSc
  * Returns true when the scalar's source representation should be preserved
  * for canonical round-trip — i.e. the source form differs from `String(value)`
  * but resolves to the same value.
+ *
+ * Special-float values (NaN, +/-Infinity) are excluded: their canonical YAML
+ * spelling is the lowercase `.inf` / `.nan` form per spec §10.3, so source
+ * variants like `.INF` or `.NaN` should normalize on round-trip rather than
+ * preserve.
  */
 function shouldPreserveRaw(rawValue: string, value: unknown): boolean {
 	if (typeof value === "number") {
+		if (Number.isNaN(value) || !Number.isFinite(value)) return false;
 		return rawValue !== String(value);
 	}
 	return false;

--- a/src/utils/composer.ts
+++ b/src/utils/composer.ts
@@ -135,6 +135,21 @@ function getScalarStyle(node: CstNode): ScalarStyle {
 	return "plain";
 }
 
+/**
+ * Extracts the chomp indicator from a block scalar's header.
+ * Returns "strip" for `-`, "keep" for `+`, "clip" otherwise (default).
+ * Returns undefined for non-block scalars.
+ */
+function getBlockChomp(node: CstNode): "strip" | "clip" | "keep" | undefined {
+	if (node.type !== "block-scalar") return undefined;
+	const src = node.source.trimStart();
+	const headerEnd = src.indexOf("\n");
+	const header = headerEnd === -1 ? src : src.slice(0, headerEnd);
+	if (header.includes("+")) return "keep";
+	if (header.includes("-")) return "strip";
+	return "clip";
+}
+
 function getScalarValue(node: CstNode, fullText?: string): string {
 	if (node.type === "block-scalar") return decodeBlockScalar(node.source, fullText, node.offset);
 	const style = getScalarStyle(node);
@@ -1071,6 +1086,13 @@ function makeScalar(cst: CstNode, state: ComposerState, meta?: NodeMeta): YamlSc
 	const style = getScalarStyle(cst);
 	const rawValue = getScalarValue(cst, state.text);
 	const value = resolveScalar(rawValue, style, meta?.tag, state);
+	const chomp = getBlockChomp(cst);
+	// Preserve the source representation when the resolved value is non-string
+	// (number/bool/null) and the source form is not the canonical JS output —
+	// e.g. `0xFFEEBB` resolves to 16772795 but should round-trip as hex,
+	// `450.00` resolves to 450 but should keep the trailing zeros.
+	const needsRaw =
+		style === "plain" && typeof value !== "string" && value !== undefined && shouldPreserveRaw(rawValue, value);
 	const scalar = new YamlScalar({
 		value,
 		style,
@@ -1079,9 +1101,23 @@ function makeScalar(cst: CstNode, state: ComposerState, meta?: NodeMeta): YamlSc
 		...(meta?.tag !== undefined ? { tag: meta.tag } : {}),
 		...(meta?.anchor !== undefined ? { anchor: meta.anchor } : {}),
 		...(meta?.comment !== undefined ? { comment: meta.comment } : {}),
+		...(chomp !== undefined ? { chomp } : {}),
+		...(needsRaw ? { raw: rawValue } : {}),
 	});
 	if (meta?.anchor) registerAnchor(scalar, meta.anchor, state, cst.offset);
 	return scalar;
+}
+
+/**
+ * Returns true when the scalar's source representation should be preserved
+ * for canonical round-trip — i.e. the source form differs from `String(value)`
+ * but resolves to the same value.
+ */
+function shouldPreserveRaw(rawValue: string, value: unknown): boolean {
+	if (typeof value === "number") {
+		return rawValue !== String(value);
+	}
+	return false;
 }
 
 /**
@@ -1660,6 +1696,7 @@ function flattenBlockMapChildren(
 				);
 				const plainMeta = combinedPending();
 				const resolved = resolveScalar(value, "plain", plainMeta.tag, state);
+				const needsRaw = typeof resolved !== "string" && resolved !== undefined && shouldPreserveRaw(value, resolved);
 				const scalar = new YamlScalar({
 					value: resolved,
 					style: "plain" as ScalarStyle,
@@ -1667,6 +1704,7 @@ function flattenBlockMapChildren(
 					length: child.length,
 					...(plainMeta.tag !== undefined ? { tag: plainMeta.tag } : {}),
 					...(plainMeta.anchor !== undefined ? { anchor: plainMeta.anchor } : {}),
+					...(needsRaw ? { raw: value } : {}),
 				});
 				if (plainMeta.anchor) registerAnchor(scalar, plainMeta.anchor, state, child.offset);
 				resetAllMeta();
@@ -2364,11 +2402,20 @@ function composeBlockSeq(cst: CstNode, state: ComposerState, meta?: NodeMeta): Y
 	const items: YamlNode[] = [];
 	let pendingMeta: NodeMeta = {};
 	let sawEntry = false;
+	// Track whether a newline appeared between the most-recent pending tag/anchor
+	// and the upcoming content. When true, the meta belongs to the resulting
+	// collection (outer scope), not to the first key/scalar within it. This
+	// mirrors the outer/inner meta split in flattenBlockMapChildren.
+	let sawNewlineSincePending = false;
 
 	for (let ci = 0; ci < children.length; ci++) {
 		const child = children[ci];
 		if (!child) continue;
-		if (child.type === "newline" || child.type === "comment") continue;
+		if (child.type === "newline") {
+			if (hasMeta(pendingMeta)) sawNewlineSincePending = true;
+			continue;
+		}
+		if (child.type === "comment") continue;
 		if (child.type === "whitespace") {
 			// "-" is the sequence entry indicator
 			if (child.source.trim() === "-") {
@@ -2420,9 +2467,20 @@ function composeBlockSeq(cst: CstNode, state: ComposerState, meta?: NodeMeta): Y
 			const nextSig = findNextSignificantChild(children, ci + 1, true);
 			const nextSigChild = nextSig !== null ? children[nextSig] : undefined;
 			if (nextSig !== null && nextSigChild && nextSigChild.type === "block-map") {
-				const keyScalar = makeScalar(child, state, hasMeta(pendingMeta) ? pendingMeta : undefined);
-				const map = composeBlockMap(nextSigChild, state, keyScalar, undefined);
+				// When pending meta is separated from the implicit-map's first key
+				// by a newline, the meta applies to the OUTER collection (the map),
+				// not to the inner key. Example: `- !!map\n  key: value` — `!!map`
+				// tags the map, while `key` keeps no meta.
+				let keyMeta: NodeMeta | undefined = hasMeta(pendingMeta) ? pendingMeta : undefined;
+				let mapMeta: NodeMeta | undefined;
+				if (sawNewlineSincePending && hasMeta(pendingMeta)) {
+					mapMeta = pendingMeta;
+					keyMeta = undefined;
+				}
+				const keyScalar = makeScalar(child, state, keyMeta);
+				const map = composeBlockMap(nextSigChild, state, keyScalar, mapMeta);
 				pendingMeta = {};
+				sawNewlineSincePending = false;
 				sawEntry = false;
 				items.push(map);
 				ci = nextSig;
@@ -2457,6 +2515,7 @@ function composeBlockSeq(cst: CstNode, state: ComposerState, meta?: NodeMeta): Y
 			}
 			const scalar = makeScalar(child, state, hasMeta(pendingMeta) ? pendingMeta : undefined);
 			pendingMeta = {};
+			sawNewlineSincePending = false;
 			sawEntry = false;
 			items.push(scalar);
 			continue;
@@ -2465,6 +2524,7 @@ function composeBlockSeq(cst: CstNode, state: ComposerState, meta?: NodeMeta): Y
 			checkAnchorOnAlias(pendingMeta, child, state);
 			const alias = makeAlias(child, state);
 			pendingMeta = {};
+			sawNewlineSincePending = false;
 			sawEntry = false;
 			items.push(alias);
 			continue;
@@ -2484,6 +2544,7 @@ function composeBlockSeq(cst: CstNode, state: ComposerState, meta?: NodeMeta): Y
 				});
 				if (pendingMeta.anchor) registerAnchor(emptyKey, pendingMeta.anchor, state, child.offset);
 				pendingMeta = {};
+				sawNewlineSincePending = false;
 				const map = composeBlockMap(child, state, emptyKey, undefined);
 				sawEntry = false;
 				items.push(map);
@@ -2491,6 +2552,7 @@ function composeBlockSeq(cst: CstNode, state: ComposerState, meta?: NodeMeta): Y
 			}
 			const map = composeBlockMap(child, state, undefined, hasMeta(pendingMeta) ? pendingMeta : undefined);
 			pendingMeta = {};
+			sawNewlineSincePending = false;
 			sawEntry = false;
 			items.push(map);
 			continue;
@@ -2498,6 +2560,7 @@ function composeBlockSeq(cst: CstNode, state: ComposerState, meta?: NodeMeta): Y
 		if (child.type === "block-seq") {
 			const seq = composeBlockSeq(child, state, hasMeta(pendingMeta) ? pendingMeta : undefined);
 			pendingMeta = {};
+			sawNewlineSincePending = false;
 			sawEntry = false;
 			items.push(seq);
 			continue;
@@ -3011,6 +3074,21 @@ function composeDocument(
 
 	let i = 0;
 	const meta: NodeMeta = {};
+	// Track meta carried across a newline. When the doc-level processor sees
+	// `&a !!t1\n&b !!t2 key: ...`, the first meta belongs to the outer container
+	// (root map) and the second to the inner first key. Without this split, the
+	// later meta would silently overwrite the earlier one.
+	const outerMeta: NodeMeta = {};
+	let sawNewlineSinceMeta = false;
+	const commitMetaAcrossNewline = () => {
+		if (sawNewlineSinceMeta && hasMeta(meta)) {
+			if (meta.tag !== undefined) outerMeta.tag = meta.tag;
+			if (meta.anchor !== undefined) outerMeta.anchor = meta.anchor;
+			if (meta.comment !== undefined) outerMeta.comment = meta.comment;
+			clearMeta(meta);
+		}
+		sawNewlineSinceMeta = false;
+	};
 
 	while (i < children.length) {
 		const child = children[i];
@@ -3038,6 +3116,9 @@ function composeDocument(
 		}
 
 		// Trivia
+		if (child.type === "newline" && hasMeta(meta)) {
+			sawNewlineSinceMeta = true;
+		}
 		if (child.type === "whitespace" || child.type === "newline") {
 			// Detect stray flow-closing brackets at document level
 			if (child.type === "whitespace" && (child.source === "]" || child.source === "}")) {
@@ -3081,13 +3162,16 @@ function composeDocument(
 			continue;
 		}
 
-		// Anchor/tag metadata
+		// Anchor/tag metadata. When a newline preceded the new meta and meta was
+		// already set, the existing meta belongs to the outer container.
 		if (child.type === "anchor") {
+			commitMetaAcrossNewline();
 			meta.anchor = getAnchorName(child, state.text);
 			i++;
 			continue;
 		}
 		if (child.type === "tag") {
+			commitMetaAcrossNewline();
 			meta.tag = child.source;
 			i++;
 			continue;
@@ -3097,49 +3181,71 @@ function composeDocument(
 			// Check if next meaningful child is a block-map (this scalar is a key)
 			const nextContent = findNextContentChild(children, i + 1);
 			if (nextContent && nextContent.type === "block-map") {
-				// When metadata (tag/anchor) appears after a document-start marker (---),
-				// it applies to the root mapping node. Otherwise, it applies to the key.
-				if (hasDocStart && hasMeta(meta)) {
-					const mapMeta = { ...meta };
-					const key = makeScalar(child, state);
-					clearMeta(meta);
-					contents = composeBlockMap(nextContent, state, key, mapMeta);
+				// Resolve which meta attaches to the root map vs. the first key.
+				// - If outer meta exists (collected across a newline), it belongs to
+				//   the map. The current `meta` belongs to the key.
+				// - Otherwise, with `hasDocStart`, the current meta is map-level
+				//   (preserves prior behavior — no key-level metadata possible).
+				// - Otherwise, the current meta belongs to the key.
+				let mapMeta: NodeMeta | undefined;
+				let keyMeta: NodeMeta | undefined;
+				if (hasMeta(outerMeta)) {
+					mapMeta = { ...outerMeta };
+					keyMeta = hasMeta(meta) ? { ...meta } : undefined;
+				} else if (hasDocStart && hasMeta(meta)) {
+					mapMeta = { ...meta };
+					keyMeta = undefined;
 				} else {
-					const key = makeScalar(child, state, hasMeta(meta) ? { ...meta } : undefined);
-					clearMeta(meta);
-					contents = composeBlockMap(nextContent, state, key);
+					keyMeta = hasMeta(meta) ? { ...meta } : undefined;
 				}
+				const key = makeScalar(child, state, keyMeta);
+				clearMeta(meta);
+				clearMeta(outerMeta);
+				sawNewlineSinceMeta = false;
+				contents = composeBlockMap(nextContent, state, key, mapMeta);
 				i = indexOfChild(children, nextContent) + 1;
 				continue;
 			}
 			// Check if followed by ":" (value-sep) — flat mapping without block-map wrapper
 			if (hasValueSepAfter(children, i + 1)) {
-				if (hasDocStart && hasMeta(meta)) {
-					const mapMeta = { ...meta };
-					const key = makeScalar(child, state);
-					clearMeta(meta);
-					contents = composeFlatBlockMap(children, i + 1, cst, state, key, mapMeta);
+				let mapMeta: NodeMeta | undefined;
+				let keyMeta: NodeMeta | undefined;
+				if (hasMeta(outerMeta)) {
+					mapMeta = { ...outerMeta };
+					keyMeta = hasMeta(meta) ? { ...meta } : undefined;
+				} else if (hasDocStart && hasMeta(meta)) {
+					mapMeta = { ...meta };
+					keyMeta = undefined;
 				} else {
-					const key = makeScalar(child, state, hasMeta(meta) ? { ...meta } : undefined);
-					clearMeta(meta);
-					contents = composeFlatBlockMap(children, i + 1, cst, state, key);
+					keyMeta = hasMeta(meta) ? { ...meta } : undefined;
 				}
+				const key = makeScalar(child, state, keyMeta);
+				clearMeta(meta);
+				clearMeta(outerMeta);
+				sawNewlineSinceMeta = false;
+				contents = composeFlatBlockMap(children, i + 1, cst, state, key, mapMeta);
 				break; // consumed all remaining children
 			}
 			// Standalone scalar — try multi-line plain scalar merging
 			if (child.type === "flow-scalar" && getScalarStyle(child) === "plain") {
 				const { value, nextIdx, partsCount } = collectMultilinePlainScalar(children, i, undefined, state.text);
-				const resolved = resolveScalar(value, "plain", meta.tag, state);
+				// Combine outer + inner meta — for a scalar root, both apply to it.
+				const combined: NodeMeta = { ...outerMeta };
+				if (meta.tag !== undefined) combined.tag = meta.tag;
+				if (meta.anchor !== undefined) combined.anchor = meta.anchor;
+				const resolved = resolveScalar(value, "plain", combined.tag, state);
 				contents = new YamlScalar({
 					value: resolved,
 					style: "plain" as ScalarStyle,
 					offset: child.offset,
 					length: child.length,
-					...(meta.tag !== undefined ? { tag: meta.tag } : {}),
-					...(meta.anchor !== undefined ? { anchor: meta.anchor } : {}),
+					...(combined.tag !== undefined ? { tag: combined.tag } : {}),
+					...(combined.anchor !== undefined ? { anchor: combined.anchor } : {}),
 				});
-				if (meta.anchor) registerAnchor(contents, meta.anchor, state, child.offset);
+				if (combined.anchor) registerAnchor(contents, combined.anchor, state, child.offset);
 				clearMeta(meta);
+				clearMeta(outerMeta);
+				sawNewlineSinceMeta = false;
 				// If the multiline scalar merged multiple parts and the remaining
 				// content forms a mapping, that mapping is trailing garbage (2CMS).
 				if (partsCount > 1) {
@@ -3167,23 +3273,41 @@ function composeDocument(
 				i = nextIdx;
 				continue;
 			}
-			contents = makeScalar(child, state, hasMeta(meta) ? { ...meta } : undefined);
+			// Combine outer + inner meta for scalar root.
+			const combined: NodeMeta = { ...outerMeta };
+			if (meta.tag !== undefined) combined.tag = meta.tag;
+			if (meta.anchor !== undefined) combined.anchor = meta.anchor;
+			contents = makeScalar(child, state, hasMeta(combined) ? combined : undefined);
 			clearMeta(meta);
+			clearMeta(outerMeta);
+			sawNewlineSinceMeta = false;
 			i++;
 			continue;
 		}
 
 		if (child.type === "block-map") {
-			contents = composeBlockMap(child, state, undefined, hasMeta(meta) ? { ...meta } : undefined);
+			// Outer meta belongs to the map; remaining `meta` would belong to the
+			// first key inside, but block-map's own children carry that context.
+			const combined: NodeMeta = { ...outerMeta };
+			if (meta.tag !== undefined) combined.tag = meta.tag;
+			if (meta.anchor !== undefined) combined.anchor = meta.anchor;
+			contents = composeBlockMap(child, state, undefined, hasMeta(combined) ? combined : undefined);
 			clearMeta(meta);
+			clearMeta(outerMeta);
+			sawNewlineSinceMeta = false;
 			i++;
 			continue;
 		}
 
 		if (child.type === "block-seq") {
 			const isRootSeq = contents === null;
-			contents = composeBlockSeq(child, state, hasMeta(meta) ? { ...meta } : undefined);
+			const combined: NodeMeta = { ...outerMeta };
+			if (meta.tag !== undefined) combined.tag = meta.tag;
+			if (meta.anchor !== undefined) combined.anchor = meta.anchor;
+			contents = composeBlockSeq(child, state, hasMeta(combined) ? combined : undefined);
 			clearMeta(meta);
+			clearMeta(outerMeta);
+			sawNewlineSinceMeta = false;
 			i++;
 			// Only check for trailing content when the block-seq is the root document
 			// value (BD7L, TD5N). When it's a value inside a mapping (57H4), the
@@ -3195,16 +3319,28 @@ function composeDocument(
 		}
 
 		if (child.type === "flow-map") {
-			const flowMap = composeFlowMap(child, state, hasMeta(meta) ? { ...meta } : undefined);
+			const nextAfterFlowMap0 = findNextContentChild(children, i + 1);
+			const flowIsKey = !!nextAfterFlowMap0 && nextAfterFlowMap0.type === "block-map";
+			let flowMeta: NodeMeta | undefined;
+			let mapMeta: NodeMeta | undefined;
+			if (flowIsKey && hasMeta(outerMeta)) {
+				mapMeta = { ...outerMeta };
+				flowMeta = hasMeta(meta) ? { ...meta } : undefined;
+			} else {
+				const combined: NodeMeta = { ...outerMeta };
+				if (meta.tag !== undefined) combined.tag = meta.tag;
+				if (meta.anchor !== undefined) combined.anchor = meta.anchor;
+				flowMeta = hasMeta(combined) ? combined : undefined;
+			}
+			const flowMap = composeFlowMap(child, state, flowMeta);
 			clearMeta(meta);
+			clearMeta(outerMeta);
+			sawNewlineSinceMeta = false;
 			i++;
-			// Check if flow collection is a mapping key (followed by block-map with ":")
-			const nextAfterFlowMap = findNextContentChild(children, i);
-			if (nextAfterFlowMap && nextAfterFlowMap.type === "block-map") {
-				// Flow map is a key — compose the block-map with this as the first key
-				const map = composeBlockMap(nextAfterFlowMap, state, flowMap);
+			if (flowIsKey && nextAfterFlowMap0) {
+				const map = composeBlockMap(nextAfterFlowMap0, state, flowMap, mapMeta);
 				contents = map;
-				while (i < children.length && children[i] !== nextAfterFlowMap) i++;
+				while (i < children.length && children[i] !== nextAfterFlowMap0) i++;
 				i++;
 			} else {
 				contents = flowMap;
@@ -3214,14 +3350,29 @@ function composeDocument(
 		}
 
 		if (child.type === "flow-seq") {
-			const flowSeq = composeFlowSeq(child, state, hasMeta(meta) ? { ...meta } : undefined);
+			const nextAfterFlowSeq0 = findNextContentChild(children, i + 1);
+			const flowIsKey = !!nextAfterFlowSeq0 && nextAfterFlowSeq0.type === "block-map";
+			let flowMeta: NodeMeta | undefined;
+			let mapMeta: NodeMeta | undefined;
+			if (flowIsKey && hasMeta(outerMeta)) {
+				mapMeta = { ...outerMeta };
+				flowMeta = hasMeta(meta) ? { ...meta } : undefined;
+			} else {
+				const combined: NodeMeta = { ...outerMeta };
+				if (meta.tag !== undefined) combined.tag = meta.tag;
+				if (meta.anchor !== undefined) combined.anchor = meta.anchor;
+				flowMeta = hasMeta(combined) ? combined : undefined;
+			}
+			const flowSeq = composeFlowSeq(child, state, flowMeta);
 			clearMeta(meta);
+			clearMeta(outerMeta);
+			sawNewlineSinceMeta = false;
 			i++;
 			// Check if flow collection is a mapping key (followed by block-map with ":")
 			const nextAfterFlowSeq = findNextContentChild(children, i);
 			if (nextAfterFlowSeq && nextAfterFlowSeq.type === "block-map") {
 				// Flow seq is a key — compose the block-map with this as the first key
-				const map = composeBlockMap(nextAfterFlowSeq, state, flowSeq);
+				const map = composeBlockMap(nextAfterFlowSeq, state, flowSeq, mapMeta);
 				contents = map;
 				// Skip past the block-map node
 				while (i < children.length && children[i] !== nextAfterFlowSeq) i++;

--- a/src/utils/stringify.ts
+++ b/src/utils/stringify.ts
@@ -305,11 +305,21 @@ function renderSingleQuotedMultiline(s: string, indent: string): string | null {
 
 /**
  * Renders a string scalar using block literal style (pipe `|`).
+ *
+ * @param explicitChomp - Original chomp indicator from the AST, when known.
+ * `keep` (`+`) and `strip` (`-`) preserve trailing-newline semantics that
+ * cannot be inferred from the resolved value alone.
  */
-function renderBlockLiteral(s: string, indent: string): string {
-	// Determine chomp indicator
+function renderBlockLiteral(s: string, indent: string, explicitChomp?: "strip" | "clip" | "keep"): string {
+	// Compute chomp indicator from the value's trailing-newline structure.
+	// `+` (keep) is required when the value retains more than one trailing
+	// newline OR when the value consists solely of newlines (otherwise `|`
+	// with empty content would parse as the empty string, losing the trailing
+	// newline). `-` (strip) is required when the value has no trailing
+	// newline. Default (clip `|`) preserves exactly one trailing newline.
 	let chomp = "";
-	if (s.endsWith("\n\n")) {
+	const onlyNewlines = s.length > 0 && /^\n+$/.test(s);
+	if (s.endsWith("\n\n") || (onlyNewlines && explicitChomp === "keep")) {
 		chomp = "+";
 	} else if (!s.endsWith("\n")) {
 		chomp = "-";
@@ -321,10 +331,14 @@ function renderBlockLiteral(s: string, indent: string): string {
 	}
 	// Explicit indent indicator needed when:
 	// - First content line starts with space (reader would misdetect indent)
-	// - Value starts with empty lines (reader can't auto-detect indent)
+	// - Value starts with empty lines AND has actual content (reader can't
+	//   auto-detect indent from leading blanks).
+	// When there is no content at all (only newlines), the indicator is needed
+	// only for keep-chomp (`|+`) since the trailing blanks form the value and
+	// the reader otherwise has no way to detect block indentation.
 	let indentIndicator = "";
 	const firstContent = lines.find((l) => l !== "");
-	if (firstContent?.startsWith(" ") || (lines.length > 0 && lines[0] === "")) {
+	if (firstContent?.startsWith(" ") || (lines.length > 0 && lines[0] === "" && firstContent !== undefined)) {
 		indentIndicator = String(indent.length);
 	}
 	return `|${indentIndicator}${chomp}\n${lines.map((l) => (l === "" ? "" : `${indent}${l}`)).join("\n")}`;
@@ -434,7 +448,14 @@ function renderBlockFolded(s: string, indent: string): string {
  * would be ambiguous. Block literal and block folded styles are always
  * accepted for single-line strings even though the output is unusual.
  */
-function renderString(s: string, style: ScalarStyle, indent: string, ignoreType = false, canonical = false): string {
+function renderString(
+	s: string,
+	style: ScalarStyle,
+	indent: string,
+	ignoreType = false,
+	canonical = false,
+	explicitChomp?: "strip" | "clip" | "keep",
+): string {
 	if (s.includes("\n")) {
 		// If the value contains C0 control chars (except tab) or carriage
 		// returns, block styles can't represent them — use double-quoted
@@ -448,8 +469,12 @@ function renderString(s: string, style: ScalarStyle, indent: string, ignoreType 
 		}
 		if (hasControl) return renderDoubleQuoted(s, canonical);
 		// If the value is only spaces and newlines (no text/tab content),
-		// block scalars can't represent it faithfully — use double-quoted
-		if (/^[\n ]*$/.test(s)) return renderDoubleQuoted(s, canonical);
+		// block scalars can't represent it faithfully — use double-quoted.
+		// Exception: when the original style is block-literal with keep-chomp
+		// content (newline-only is a valid `|+` body), preserve block style.
+		if (/^[\n ]*$/.test(s) && style !== "block-literal" && style !== "block-folded") {
+			return renderDoubleQuoted(s, canonical);
+		}
 		// In canonical mode, multi-line block content with trailing whitespace
 		// on an interior line cannot round-trip cleanly — block scalars normalise
 		// such whitespace. Single-line content with only trailing whitespace
@@ -467,7 +492,7 @@ function renderString(s: string, style: ScalarStyle, indent: string, ignoreType 
 			}
 		}
 		// Multi-line: prefer block styles
-		if (style === "block-literal") return renderBlockLiteral(s, indent);
+		if (style === "block-literal") return renderBlockLiteral(s, indent, explicitChomp);
 		if (style === "block-folded") return renderBlockFolded(s, indent);
 		// In canonical mode, prefer single-quoted with fold encoding for plain
 		// and single-quoted multi-line scalars — matches libyaml canonical form.
@@ -476,7 +501,7 @@ function renderString(s: string, style: ScalarStyle, indent: string, ignoreType 
 				const sq = renderSingleQuotedMultiline(s, indent);
 				if (sq !== null) return sq;
 			}
-			return renderBlockLiteral(s, indent);
+			return renderBlockLiteral(s, indent, explicitChomp);
 		}
 		return renderDoubleQuoted(s, canonical);
 	}
@@ -510,10 +535,27 @@ function renderString(s: string, style: ScalarStyle, indent: string, ignoreType 
 		case "double-quoted":
 			return renderDoubleQuoted(s, canonical);
 		case "block-literal":
-			return renderBlockLiteral(s, indent);
+			return renderBlockLiteral(s, indent, explicitChomp);
 		case "block-folded":
 			return renderBlockFolded(s, indent);
 	}
+}
+
+/**
+ * Returns true if the rendered text ends with an open-ended block scalar
+ * (`|+` or `>+` keep-chomp). Such scalars consume any trailing blank lines
+ * up to the next document marker, so an explicit `...` is required for the
+ * reader to know where the value ends.
+ *
+ * Detects the most recent `|` or `>` indicator on a header line (matching
+ * the form `|<digits>?<chomp>?$` after optional indent and node prefixes)
+ * and returns true when the chomp indicator is `+`.
+ */
+function endsWithKeepChomp(rendered: string): boolean {
+	const match = rendered.match(/[|>][1-9]?[+-]?$|[|>][1-9]?[+-]?(?=\n)/g);
+	if (!match) return false;
+	const last = match[match.length - 1];
+	return last.includes("+");
 }
 
 // ---------------------------------------------------------------------------
@@ -850,6 +892,8 @@ function normalizeNodeTags(node: YamlNode, tagMap: Map<string, string>): YamlNod
 			tag: norm(node.tag),
 			anchor: node.anchor,
 			comment: node.comment,
+			...(node.chomp !== undefined ? { chomp: node.chomp } : {}),
+			...(node.raw !== undefined ? { raw: node.raw } : {}),
 			offset: node.offset,
 			length: node.length,
 		});
@@ -901,6 +945,8 @@ export function stripNodeComments(node: YamlNode): YamlNode {
 			style: node.style,
 			tag: node.tag,
 			anchor: node.anchor,
+			...(node.chomp !== undefined ? { chomp: node.chomp } : {}),
+			...(node.raw !== undefined ? { raw: node.raw } : {}),
 			offset: node.offset,
 			length: node.length,
 		});
@@ -989,10 +1035,13 @@ function stringifyScalarNodeLines(node: InstanceType<typeof YamlScalar>, ctx: St
 	} else if (typeof val === "boolean") {
 		lines = [val ? "true" : "false"];
 	} else if (typeof val === "number") {
-		lines = [renderNumber(val)];
+		// Prefer the source representation when available so non-canonical
+		// numeric formats (hex `0xFFEEBB`, trailing zeros `450.00`) survive
+		// the round-trip.
+		lines = [node.raw !== undefined ? node.raw : renderNumber(val)];
 	} else if (typeof val === "string") {
 		// When a tag is present, type-conflict quoting is unnecessary
-		const rendered = renderString(val, style, " ".repeat(ctx.indent), !!node.tag, ctx.forceDefaultStyles);
+		const rendered = renderString(val, style, " ".repeat(ctx.indent), !!node.tag, ctx.forceDefaultStyles, node.chomp);
 		lines = rendered.split("\n");
 	} else {
 		lines = [renderDoubleQuoted(String(val))];
@@ -1052,8 +1101,16 @@ function stringifyMapNodeLines(node: InstanceType<typeof YamlMap>, ctx: Stringif
 			const keyLines = stringifyNodeLines(pair.key, ctx);
 			// Emit "? " followed by the key
 			lines.push(`? ${keyLines[0]}`);
+			// When the first key line is just metadata (`&anchor` and/or `!tag`),
+			// the continuation lines are the actual collection content and should
+			// be emitted without an extra indent — they sit at the same level as
+			// `?` (compact form). Otherwise, indent continuation lines normally.
+			const firstTokens = keyLines[0].trim().split(/\s+/).filter(Boolean);
+			const firstIsMetaOnly =
+				firstTokens.length > 0 && firstTokens.every((t) => t.startsWith("&") || t.startsWith("!"));
+			const contPad = firstIsMetaOnly ? "" : pad;
 			for (let k = 1; k < keyLines.length; k++) {
-				lines.push(`${pad}${keyLines[k]}`);
+				lines.push(`${contPad}${keyLines[k]}`);
 			}
 			// Emit ": " followed by the value
 			const valNode = pair.value;
@@ -1433,7 +1490,11 @@ export function stringifyDocument(
 			const result = stringifyNodeLines(contents, ctx).join("\n");
 			const body = opts.finalNewline ? `${result}\n` : result;
 
-			const docEnd = doc.hasDocumentEnd ? "...\n" : "";
+			// In canonical mode, an explicit `...` end marker is required when the
+			// final emitted scalar uses keep-chomp (`|+` or `>+`) — without it the
+			// reader cannot tell where the open-ended block scalar ends.
+			const needsTerminatorForKeepChomp = ctx.forceDefaultStyles && endsWithKeepChomp(result);
+			const docEnd = doc.hasDocumentEnd || needsTerminatorForKeepChomp ? "...\n" : "";
 
 			if (doc.hasDocumentStart) {
 				const rootTag = contents && "tag" in contents ? contents.tag : undefined;


### PR DESCRIPTION
## Summary

- Raises YAML 1.2 spec compliance from 97.47% (2348/2409) to 97.93% (2374/2424).
- Adds two optional public fields to YamlScalar: `chomp` and `raw`. Both backward-compatible additive changes.
- Removes 11 entries from the canonical-output skip map.

## Changes

Six independent fixes:

1. Block scalar chomp preservation — composer extracts the source `+`/`-`/clip indicator into a new `chomp` field on YamlScalar so keep-chomp blocks survive round-trip. Stringifier picks the chomp marker from the value's trailing-newline structure, with `+` reserved for newline-only content (where clip would lose the trailing newline).
2. Document-end marker for keep-chomp — stringifier auto-emits `...` after a document whose final scalar is `|+`/`>+` in canonical mode.
3. Newline-only block content — fixed regression that converted `|+` blocks with empty content to double-quoted.
4. Source numeric format preservation — new `raw` field on YamlScalar retains source representation so `0xFFEEBB` stays hex and `450.00` keeps its trailing zeros.
5. Tag-on-block-collection (newline-aware) — when a sequence entry's pending tag/anchor crosses a newline before the implicit-map first key, the meta now attaches to the inner map rather than the key.
6. Document-level outer/inner meta split — composer now tracks meta carried across a newline so `&a4 !!map\n&a5 !!str key:` correctly splits between the root mapping and the first key. Threads through the flow-collection-as-key path used by 6BFJ.

Also: compact `?`-key continuation now emits no extra padding when the first key line is metadata only (anchor/tag tokens).

## Newly passing canonical-output tests

F8F9, JEF9/00, JEF9/01, JEF9/02, 6JWB, 735Y, C4HZ, UGM3, 9KAX, 6BFJ.

## Test plan

- [x] Unit tests pass (`pnpm run test`)
- [x] Filtered compliance tests pass (`pnpm run test:compliance`)
- [x] Raw compliance: 2374/2424 (97.93%), 50 failures (was 61)
- [x] No regressions in previously-passing canonical-output tests

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>