### PR TITLE
fix(parser): tighten leniency to reject 8 categories of malformed YAML

### DIFF
--- a/.changeset/silver-wolves-sleep.md
+++ b/.changeset/silver-wolves-sleep.md
@@ -1,0 +1,14 @@
+---
+"yaml-effect": patch
+---
+
+## Bug Fixes
+
+- Fixed parser leniency that caused several categories of malformed YAML 1.2 to be silently accepted instead of rejected. Inputs now correctly produce a `YamlComposerError`:
+  - Block-mapping keys appearing at a column that does not match the established sibling-key column (misaligned dashes).
+  - A nested block sequence positioned at a column that places it in mapping-key position rather than as a sibling sequence entry.
+  - A mapping pattern (`key: value`) opening on the same line as the `---` document-start marker.
+  - A stray comma appearing in block (non-flow) context, such as inside a tag handle expression.
+- Raw YAML 1.2 test-suite compliance increases from 97.93% to 98.27% (+8 tests now correctly rejected).
+
+Inputs that previously parsed into structurally degenerate values — such as mappings with empty-string keys produced by misaligned dashes — now fail with `YamlComposerError`. Code relying on the lenient legacy behavior will need to handle the error or fix the YAML source. The `YamlErrorCode` union is unchanged at the type level; only the runtime emission set has expanded to include `"InvalidIndentation"` and `"UnexpectedToken"` for these previously-passing inputs.

--- a/.claude/design/yaml-effect/compliance-testing.md
+++ b/.claude/design/yaml-effect/compliance-testing.md
@@ -413,10 +413,11 @@ into per-category issues (#15, #16).
 | #15 | Parser rejects valid YAML | **Resolved** (0 remaining XFAIL "rejects valid") |
 | #16 | Parser accepts invalid YAML | Open (15 XFAIL "accepts invalid") |
 
-Current compliance: 2382/2424 raw assertions passing (98.27%), filtered
-assertions passing, 15 XFAIL (all "accepts invalid"), 0 JSON comparison
-failures, 0 roundtrip failures, ~28 SKIP_ASSERTIONS entries (output
-only). Use `pnpm run test:compliance-raw` to see unfiltered results.
+Current compliance: 2382/2424 raw assertions passing (98.27%), 1198
+filtered assertions passing, 15 XFAIL (all "accepts invalid"), 0 JSON
+comparison failures, 0 roundtrip failures, ~28 SKIP_ASSERTIONS entries
+(output only). Use `pnpm run test:compliance-raw` to see unfiltered
+results.
 
 Remaining canonical-output gaps cluster into a few categories:
 

--- a/.claude/design/yaml-effect/compliance-testing.md
+++ b/.claude/design/yaml-effect/compliance-testing.md
@@ -5,9 +5,9 @@ status: current
 module: yaml-effect
 category: testing
 created: 2026-03-14
-updated: 2026-04-26
-last-synced: 2026-04-26
-completeness: 92
+updated: 2026-04-27
+last-synced: 2026-04-27
+completeness: 93
 related:
   - architecture.md
   - parsing.md
@@ -184,7 +184,7 @@ export const XFAIL: Record<string, string> = { ... };
 Tests that run with `it.fails` -- the test is expected to fail. One
 remaining category of XFAIL entries:
 
-1. **Parser accepts invalid YAML** (29 tests) -- our parser succeeds on
+1. **Parser accepts invalid YAML** (15 tests) -- our parser succeeds on
    input the spec says should be rejected. Missing validation for various
    structural constraints (indentation, anchors, flow collection syntax).
 
@@ -411,13 +411,12 @@ into per-category issues (#15, #16).
 | #10 | Add stricter validation for invalid YAML rejection | Closed (decomposed into #15, #16) |
 | #11 | Fix canonical output and roundtrip stringifier compliance | **Mostly resolved** (roundtrip 18->0, output 59->38) |
 | #15 | Parser rejects valid YAML | **Resolved** (0 remaining XFAIL "rejects valid") |
-| #16 | Parser accepts invalid YAML | Open (23 XFAIL "accepts invalid") |
+| #16 | Parser accepts invalid YAML | Open (15 XFAIL "accepts invalid") |
 
-Current compliance: 2374/2424 raw assertions passing (97.93%), 1188
-filtered assertions passing, 23 XFAIL (all "accepts invalid"), 0 JSON
-comparison failures, 0 roundtrip failures, ~28 SKIP_ASSERTIONS entries
-(output only). Use `pnpm run test:compliance-raw` to see unfiltered
-results.
+Current compliance: 2382/2424 raw assertions passing (98.27%), filtered
+assertions passing, 15 XFAIL (all "accepts invalid"), 0 JSON comparison
+failures, 0 roundtrip failures, ~28 SKIP_ASSERTIONS entries (output
+only). Use `pnpm run test:compliance-raw` to see unfiltered results.
 
 Remaining canonical-output gaps cluster into a few categories:
 
@@ -652,6 +651,66 @@ Categories of fixes:
   newline, then a flow-scalar-then-block-map (the implicit-map case),
   pending meta is routed to the outer map (`mapMeta`) rather than
   the first key. Resets on every meta-consuming code path.
+
+### Key Compliance Improvements (parser leniency)
+
+The jump from 97.93% to 98.27% raw compliance (2382/2424 assertions,
++8 assertions) cleared eight "parser accepts invalid YAML" XFAIL
+entries -- DMG6, EW3V, N4JP, U44R, ZVH3, U99R, 9KBC, CXX2 -- by adding
+structural-validation paths in the composer and one block-context
+rejection in the lexer. XFAIL count: 23 -> 15.
+
+Categories of fixes:
+
+- **Column-based key validation in `flattenBlockMapChildren`**
+  (`src/utils/composer.ts`) -- new `validateKeyColumn(col, offset, length)`
+  helper emits `InvalidIndentation` when a key column does not match
+  the externally-anchored first key column. Gated on a new
+  `hasExternalKeyColumn` flag so malformed CSTs without a trustworthy
+  parent column (KK5P) still parse. New `pendingExplicitKeyCol` state
+  tracks the column of `?` so explicit keys with continuation content
+  use the `?` column for indentation tracking. The scalar+block-map
+  first-key branch now calls `validateKeyColumn` (catches DMG6 / EW3V /
+  N4JP / U44R).
+- **Multi-line plain scalar termination on block-map sibling**
+  (`src/utils/composer.ts`, `collectMultilinePlainScalar`) -- new
+  `hasBlockMapAfterInList(children, startIdx)` helper detects when the
+  next non-trivia child after a scalar is a `block-map`. The merge
+  loop now stops on this pattern so the scalar+block-map validation
+  can fire (surfaces the EW3V misalignment).
+- **Continuation column floor for non-scalar continuations**
+  (`src/utils/composer.ts`, `collectMultilinePlainScalar`) -- the
+  non-scalar-continuation branch now applies an optional
+  `minContinuationColumn` parameter, rejecting shallower content as
+  not-a-continuation. Catches ZVH3 (`key: value\n - item1` -- the
+  col-1 block-seq is a sibling of `key`, not part of `value`). AB8U is
+  preserved because `composeBlockSeq` calls the helper without
+  `minContinuationColumn`.
+- **Block-seq in key position** (`src/utils/composer.ts`,
+  `flattenBlockMapChildren`) -- in the block-map flatten loop, a
+  non-empty block-seq with `afterValueSep === false` and no preceding
+  `?` indicator emits `InvalidIndentation`. Empty placeholder
+  block-seqs (length 0) are excluded so KK5P still parses. Catches
+  ZVH3.
+- **Mapping on document-start line** (`src/utils/composer.ts`,
+  `composeDocument`) -- when the scalar+block-map pattern is detected
+  at document level **and** `hasDocumentStart` is true **and** the
+  scalar is on the same line as `---`, the composer emits
+  `UnexpectedToken` "Mapping cannot start on document-start (---)
+  line". Catches 9KBC and CXX2.
+- **Trailing-content detection extension** (`src/utils/composer.ts`,
+  scalar root path) -- the trailing-content check now also flags
+  scalar+block-map sibling patterns (via `hasBlockMapAfterInList`).
+  Preserves the 2CMS rejection that previously relied on the
+  multi-line merge consuming "invalid".
+- **Comma in block context** (`src/utils/lexer.ts`, comma branch of
+  `scanNext`) -- when `flowDepth === 0`, a `,` emits an `error` token
+  rather than `flow-separator`. Catches U99R (`!!str, xxx`).
+- **Fatal-error filter additions** -- `InvalidIndentation` was added
+  to all three fatal-error filters (`parseDocument`,
+  `parseAllDocuments`, `composeDocumentFromCst`) so the new
+  validation errors fail the parse Effect rather than being absorbed
+  as warnings.
 
 ### Dual Block Scalar Decoders
 

--- a/.claude/design/yaml-effect/errors.md
+++ b/.claude/design/yaml-effect/errors.md
@@ -5,9 +5,9 @@ status: current
 module: yaml-effect
 category: architecture
 created: 2026-03-14
-updated: 2026-03-19
-last-synced: 2026-03-19
-completeness: 85
+updated: 2026-04-27
+last-synced: 2026-04-27
+completeness: 87
 related:
   - architecture.md
   - parsing.md
@@ -66,7 +66,10 @@ Fields:
 ### YamlComposerError
 
 Tag: `"YamlComposerError"`. Raised when composition encounters semantic
-errors (undefined aliases, duplicate anchors, unresolved tags, etc.).
+errors (undefined aliases, duplicate anchors, unresolved tags, etc.) or
+structural-validation errors detected during composition (key-column
+indentation mismatches, block-seq in key position, mapping content on
+the document-start line).
 
 Fields:
 
@@ -168,7 +171,17 @@ class YamlErrorDetail extends Schema.Class("YamlErrorDetail")({
 ### YamlComposerErrorCode
 
 `UndefinedAlias`, `DuplicateAnchor`, `CircularAlias`, `UnresolvedTag`,
-`InvalidTagValue`, `AliasCountExceeded`.
+`InvalidTagValue`, `AliasCountExceeded`, `InvalidIndentation`,
+`UnexpectedToken`.
+
+The composer reuses the `InvalidIndentation` and `UnexpectedToken` codes
+from the parser-error vocabulary for structural-validation errors raised
+during composition (key-column mismatches, block-seq in key position,
+mapping starting on the document-start line). These errors are produced
+by the composer's leniency-validation helpers (see
+[parsing.md](./parsing.md) "Structural Validation in `flattenBlockMapChildren`")
+but are reported on the `YamlComposerError` channel because the composer
+is the layer that detects them.
 
 ## Error-to-Function Mapping
 

--- a/.claude/design/yaml-effect/parsing.md
+++ b/.claude/design/yaml-effect/parsing.md
@@ -5,9 +5,9 @@ status: current
 module: yaml-effect
 category: architecture
 created: 2026-03-14
-updated: 2026-03-19
-last-synced: 2026-03-19
-completeness: 85
+updated: 2026-04-27
+last-synced: 2026-04-27
+completeness: 88
 related:
   - architecture.md
   - schemas.md
@@ -74,7 +74,11 @@ The scanner handles all YAML 1.2 constructs:
 - **Quoted scalars** -- single-quoted (with `''` escape) and double-quoted
   (with full YAML 1.2 escape sequences: `\n`, `\t`, `\x`, `\u`, `\U`,
   `\N`, `\_`, `\L`, `\P`, line continuation)
-- **Flow indicators** -- `{`, `}`, `[`, `]`, `,` with flow depth tracking
+- **Flow indicators** -- `{`, `}`, `[`, `]`, `,` with flow depth tracking.
+  A `,` at `flowDepth === 0` (block context) emits an `error` token
+  rather than `flow-separator`, since commas have no meaning outside
+  flow collections. This causes inputs like `!!str, xxx` to be rejected
+  (resolves U99R).
 - **Anchors** (`&name`), **aliases** (`*name`), **tags** (`!`, `!!`, `!<>`)
 - **Block structure** -- `?` (explicit key), `-` (sequence entry), `:`
   (value indicator). These emit synthetic `block-map-start` or
@@ -177,11 +181,21 @@ styles:
   `flow-scalar` nodes (one per source line); `collectMultilinePlainScalar`
   merges consecutive plain scalars, stopping at block structure indicators
   (`?`, `:`, `-`), comments, and scalars followed by value-sep (mapping
-  keys). Continuation line detection also handles non-scalar CST nodes
+  keys). It also stops when a candidate scalar is followed by a block-map
+  sibling (detected via `hasBlockMapAfterInList`) -- such a scalar is the
+  first key of a nested implicit mapping, not a continuation, so the merge
+  must terminate so the scalar+block-map validation can fire (resolves
+  EW3V). Continuation line detection also handles non-scalar CST nodes
   (anchors, tags, aliases, directives at non-document-start positions)
-  via `extractLineContent` and `skipChildrenOnLine` helpers. Multi-line
-  explicit keys (`?` followed by indented continuation scalars) are
-  merged via `collectMultilineKey`.
+  via `extractLineContent` and `skipChildrenOnLine` helpers; in the
+  non-scalar continuation branch, an optional `minContinuationColumn`
+  parameter rejects content that returns to a shallower column than the
+  value being continued (so `key: value\n - item1` is not absorbed --
+  the col-1 block-seq is a sibling of `key`, not part of `value`).
+  `composeBlockSeq` deliberately calls `collectMultilinePlainScalar`
+  without `minContinuationColumn` to preserve AB8U-style continuation.
+  Multi-line explicit keys (`?` followed by indented continuation
+  scalars) are merged via `collectMultilineKey`.
 - **Single-quoted scalars** (`decodeSingleQuoted`): Unescapes `''` to
   `'`, then applies `foldFlowLines`.
 - **Double-quoted scalars** (`decodeDoubleQuoted`): Processes escape
@@ -258,6 +272,64 @@ structured key/value sequence. Notable behaviors:
 - `hasValueSepBetween` check prevents false scalar-before-block-map
   pattern matching (where a scalar sibling should not be absorbed as
   a key if a value separator appears between them)
+- `hasBlockMapAfterInList(children, startIdx)` -- helper that returns
+  true when the next non-trivia child after a scalar is a `block-map`
+  (i.e., the scalar is the first key of a nested implicit mapping).
+  Returns false on a sibling `:` value-sep, so it does not fire on
+  ordinary `key: value` shapes. Used both by the leniency-validation
+  branch (below) and by `collectMultilinePlainScalar` to terminate
+  merges when a scalar-then-block-map sibling pattern is detected.
+
+### Structural Validation in `flattenBlockMapChildren`
+
+The block-map flattener performs column-based key validation to reject
+malformed indentation that would otherwise silently parse as nested
+structure. State and helpers:
+
+- `pendingExplicitKeyCol` -- column of a `?` indicator that was just
+  consumed; the next key pushed uses this column (not the scalar's
+  own column) for indentation tracking, so explicit keys with
+  continuation content are anchored to `?`.
+- `hasExternalKeyColumn` -- only validate against `lastKeyColumn` when
+  the parent passed in an externally-anchored first key column. This
+  avoids false positives on malformed CSTs where the flattener cannot
+  trust its own column inference (e.g., KK5P).
+- `validateKeyColumn(col, offset, length)` -- emits an
+  `InvalidIndentation` error when `col !== lastKeyColumn` while
+  `hasExternalKeyColumn` is true.
+- `pushNode` -- before tracking `lastKeyColumn`, resolves the entry
+  indent from `pendingExplicitKeyCol` if a `?` was just consumed.
+
+Validation is applied at three points:
+
+1. **Scalar+block-map first-key path** -- when a scalar is in key
+   position and is followed by a block-map sibling (the implicit
+   nested-mapping case), `validateKeyColumn` runs against the scalar's
+   column. This catches misalignments like DMG6 / EW3V / N4JP / U44R
+   where the inner key is not aligned with the outer key column.
+2. **Block-seq in key position** -- when a non-empty block-seq appears
+   with `afterValueSep === false` and no preceding `?` indicator, the
+   flattener emits `InvalidIndentation`. Empty placeholder block-seqs
+   (`length === 0`) are excluded so KK5P still parses. Catches ZVH3.
+3. **Document-start line** -- in `composeDocument`, when the
+   scalar+block-map pattern is detected at document level **and**
+   `hasDocumentStart` is true **and** the scalar is on the same line
+   as `---`, the composer emits `UnexpectedToken` "Mapping cannot
+   start on document-start (---) line". Catches 9KBC and CXX2.
+
+### Trailing-Content Detection in Scalar Root
+
+When the document root is a scalar and additional content follows that
+cannot be merged via multi-line plain scalar collection, the composer
+flags trailing content. This now also fires for scalar+block-map
+sibling patterns (using `hasBlockMapAfterInList`), preserving the 2CMS
+rejection that previously relied on the multi-line merge consuming
+the "invalid" continuation.
+
+`InvalidIndentation` is included in all three fatal-error filters
+(`parseDocument`, `parseAllDocuments`, `composeDocumentFromCst`) so
+that these structural-validation errors fail the parse Effect rather
+than being absorbed as warnings.
 
 ### Anchor/Alias Handling
 
@@ -362,7 +434,12 @@ Composition errors produce `YamlComposerError` containing:
 - `text: string` -- the original source
 
 Error codes: `UndefinedAlias`, `DuplicateAnchor`, `CircularAlias`,
-`UnresolvedTag`, `InvalidTagValue`, `AliasCountExceeded`.
+`UnresolvedTag`, `InvalidTagValue`, `AliasCountExceeded`,
+`InvalidIndentation`, `UnexpectedToken`. The latter two are produced
+by the structural-validation paths in `flattenBlockMapChildren` and
+`composeDocument` (see "Structural Validation in
+`flattenBlockMapChildren`" above) and are reported on the
+`YamlComposerError` channel rather than `YamlParseError`.
 
 ### Block Scalar Decoding
 

--- a/__test__/utils/yaml-test-suite-skip-map.ts
+++ b/__test__/utils/yaml-test-suite-skip-map.ts
@@ -16,6 +16,9 @@
  * Updated: dual-anchor composer fix (outer/inner meta split), empty seq item anchor preservation, anchored empty key sep.
  * Updated: keep-chomp `...` terminator and chomp preservation, source numeric format preserved (hex, trailing zeros),
  *          tag-on-block-collection (newline-aware), document-level outer/inner meta split.
+ * Updated: parser leniency fixes — block-mapping indent validation (DMG6, EW3V, N4JP, U44R),
+ *          block-seq in key position (ZVH3), comma-in-tag rejection (U99R), mapping on
+ *          document-start line (9KBC, CXX2).
  */
 
 /** Tests to skip entirely — not applicable to our implementation. */
@@ -23,30 +26,22 @@ export const SKIP: Record<string, string> = {};
 
 /** Tests expected to fail at parse level — known gaps to fix later. */
 export const XFAIL: Record<string, string> = {
-	// Parser accepts invalid YAML (27)
+	// Parser accepts invalid YAML (18)
 	"4HVU": "Parser accepts invalid YAML: Wrong indendation in Sequence",
 	"4JVG": "Parser accepts invalid YAML: Scalar value with two anchors",
 	"5LLU": "Parser accepts invalid YAML: Block scalar with wrong indented line after spaces only",
 	"9C9N": "Parser accepts invalid YAML: Wrong indented flow sequence",
-	"9KBC": "Parser accepts invalid YAML: Mapping starting at --- line",
 	BS4K: "Parser accepts invalid YAML: Comment between plain scalar lines",
 	C2SP: "Parser accepts invalid YAML: Flow Mapping Key on two lines",
-	CXX2: "Parser accepts invalid YAML: Mapping with anchor on document start line",
-	DMG6: "Parser accepts invalid YAML: Wrong indendation in Map",
-	EW3V: "Parser accepts invalid YAML: Wrong indendation in mapping",
 	G9HC: "Parser accepts invalid YAML: Invalid anchor in zero indented sequence",
 	H7J7: "Parser accepts invalid YAML: Node anchor not indented",
-	N4JP: "Parser accepts invalid YAML: Bad indentation in mapping",
 	QB6E: "Parser accepts invalid YAML: Wrong indented multiline quoted scalar",
 	QLJ7: "Parser accepts invalid YAML: Tag shorthand used in documents but only defined in the first",
 	S98Z: "Parser accepts invalid YAML: Block scalar with more spaces than first content line",
 	SY6V: "Parser accepts invalid YAML: Anchor before sequence entry on same line",
-	U44R: "Parser accepts invalid YAML: Bad indentation in mapping (2)",
-	U99R: "Parser accepts invalid YAML: Invalid comma in tag",
 	"VJP3/00": "Parser accepts invalid YAML: Flow collections over many lines",
 	W9L4: "Parser accepts invalid YAML: Literal block scalar with more spaces in first line",
 	"Y79Y/009": "Parser accepts invalid YAML: Tab as block indentation after value indicator",
-	ZVH3: "Parser accepts invalid YAML: Wrong indented sequence item",
 };
 
 /**

--- a/__test__/utils/yaml-test-suite-skip-map.ts
+++ b/__test__/utils/yaml-test-suite-skip-map.ts
@@ -26,7 +26,7 @@ export const SKIP: Record<string, string> = {};
 
 /** Tests expected to fail at parse level — known gaps to fix later. */
 export const XFAIL: Record<string, string> = {
-	// Parser accepts invalid YAML (18)
+	// Parser accepts invalid YAML (15)
 	"4HVU": "Parser accepts invalid YAML: Wrong indendation in Sequence",
 	"4JVG": "Parser accepts invalid YAML: Scalar value with two anchors",
 	"5LLU": "Parser accepts invalid YAML: Block scalar with wrong indented line after spaces only",

--- a/src/utils/composer.ts
+++ b/src/utils/composer.ts
@@ -368,6 +368,10 @@ function collectMultilinePlainScalar(
 		if (child.type === "flow-scalar" && getScalarStyle(child) === "plain") {
 			// Check if this scalar is followed by `:` — if so, it's a key, stop
 			if (hasValueSepAfterInList(children, idx + 1)) break;
+			// Also stop if scalar is followed by a block-map (it's the first
+			// key of a nested mapping — i.e., an implicit key, not a value
+			// continuation). EW3V: `k1: v1\n k2: v2` — k2 is a key, don't merge.
+			if (hasBlockMapAfterInList(children, idx + 1)) break;
 
 			// Don't merge scalars below the minimum continuation indent (236B).
 			// This prevents merging e.g. "bar" (col 2) with "invalid" (col 0)
@@ -403,6 +407,14 @@ function collectMultilinePlainScalar(
 		if (sawNewline && sourceText && child.type !== "flow-scalar" && child.type !== "block-scalar") {
 			const childCol = lineCol(sourceText, child.offset).column;
 			const isDirectiveContinuation = child.type === "directive";
+			// Apply minContinuationColumn check for non-directive nodes — when
+			// the caller specifies an implicit-mapping continuation indent,
+			// nodes shallower than that aren't continuations and shouldn't
+			// be absorbed (ZVH3: `key: value\n - item1` — the nested block-seq
+			// at col 1 isn't a continuation of the value at col 7+).
+			if (minContinuationColumn !== undefined && !isDirectiveContinuation && childCol < minContinuationColumn) {
+				break;
+			}
 			// Continuation lines must be indented (column > 0), or be directives
 			if (childCol > 0 || isDirectiveContinuation) {
 				const { lineText, lineEndOffset } = extractLineContent(sourceText, child.offset);
@@ -460,6 +472,26 @@ function findNextSignificantChild(children: readonly CstNode[], startIdx: number
 
 function hasValueSepAfterInList(children: readonly CstNode[], startIdx: number): boolean {
 	return findValueSepOffset(children, startIdx) >= 0;
+}
+
+/**
+ * Check if the next non-trivia child is a block-map (indicating that the
+ * preceding scalar is the first key of a nested implicit mapping). Returns
+ * false if a sibling `:` value-sep is encountered first, since that means
+ * the scalar is a key at the current level (not a nested mapping start).
+ */
+function hasBlockMapAfterInList(children: readonly CstNode[], startIdx: number): boolean {
+	for (let j = startIdx; j < children.length; j++) {
+		const c = children[j];
+		if (!c) continue;
+		if (c.type === "newline" || c.type === "comment") continue;
+		if (c.type === "whitespace") {
+			if (c.source === ":") return false;
+			continue;
+		}
+		return c.type === "block-map";
+	}
+	return false;
 }
 
 /** Find the offset of the next ":" value separator in a CST children list, or -1 if none. */
@@ -1353,6 +1385,16 @@ function flattenBlockMapChildren(
 	let lastValueSepOffset = -1;
 	let lastKeyColumn = externalKeyColumn ?? -1;
 	let lastKeyOffset = externalKeyOffset ?? -1;
+	// Whether `lastKeyColumn` originated from an externally-provided first key
+	// (i.e., the parser placed the first key as a sibling before the block-map).
+	// Only externally-anchored columns are used for indentation validation —
+	// internally-tracked columns may include malformed CST artifacts and
+	// shouldn't trigger validation errors.
+	const hasExternalKeyColumn = externalKeyColumn !== undefined;
+	// When `?` explicit-key indicator is seen, the entry indent is the column
+	// of `?`, not of the key scalar. Track it so the next key uses the right
+	// column for indentation validation. Reset after the key is consumed.
+	let pendingExplicitKeyCol = -1;
 
 	// If we have pending meta and a newline has been seen since it was set, the
 	// pending meta applies to the surrounding context (outer container) and any
@@ -1385,12 +1427,32 @@ function flattenBlockMapChildren(
 		sawNewlineSincePending = false;
 	}
 
+	function validateKeyColumn(col: number, offset: number, length: number): void {
+		if (lastKeyColumn >= 0 && col !== lastKeyColumn) {
+			const lc = lineCol(state.text, offset);
+			state.errors.push(
+				new YamlErrorDetail({
+					code: "InvalidIndentation",
+					message: "Bad indentation in block mapping",
+					offset,
+					length,
+					line: lc.line,
+					column: lc.column,
+				}),
+			);
+		}
+	}
+
 	function pushNode(node: YamlNode, nodeOffset?: number) {
 		// Track key column/offset when pushing in key position (before value-sep)
 		if (!afterValueSep && nodeOffset !== undefined && nodeOffset >= 0) {
-			lastKeyColumn = lineCol(state.text, nodeOffset).column;
+			// If `?` explicit-key indicator preceded this scalar, the entry's
+			// indent is the `?` column. Otherwise it's the scalar's column.
+			const newCol = pendingExplicitKeyCol >= 0 ? pendingExplicitKeyCol : lineCol(state.text, nodeOffset).column;
+			lastKeyColumn = newCol;
 			lastKeyOffset = nodeOffset;
 		}
+		pendingExplicitKeyCol = -1;
 		items.push({ kind: "node", node });
 		afterValueSep = false;
 	}
@@ -1424,7 +1486,9 @@ function flattenBlockMapChildren(
 				// that the next content node is the key of this mapping entry.
 				// We don't need to push a semantic item because the node that
 				// follows will naturally be in key position (before value-sep).
-				// Reset afterValueSep so the next node is treated as a key.
+				// Track the column of `?` since the entry's indent is the
+				// `?` column, not the key scalar's column.
+				pendingExplicitKeyCol = lineCol(state.text, child.offset).column;
 				afterValueSep = false;
 				continue;
 			}
@@ -1558,6 +1622,16 @@ function flattenBlockMapChildren(
 				// that came BEFORE a newline (outerMeta) belong to the new map;
 				// anchor/tag that came AFTER the newline (pendingMeta), on the
 				// same line as the key, belong to the key itself.
+				// Validate column consistency: in key position, the scalar must
+				// match the established key column for this block mapping.
+				// Use `?` column if explicit-key indicator was seen, otherwise scalar.
+				// Only validate when externally-anchored (avoids false positives
+				// from malformed CSTs).
+				if (!afterValueSep && hasExternalKeyColumn) {
+					const scalarCol =
+						pendingExplicitKeyCol >= 0 ? pendingExplicitKeyCol : lineCol(state.text, child.offset).column;
+					validateKeyColumn(scalarCol, child.offset, child.length);
+				}
 				const keyMeta = hasMeta(pendingMeta) ? pendingMeta : undefined;
 				const mapMeta = hasMeta(outerMeta) ? outerMeta : undefined;
 				const key = makeScalar(child, state, keyMeta);
@@ -1833,6 +1907,24 @@ function flattenBlockMapChildren(
 		if (child.type === "block-seq") {
 			commitOuterIfNewlineSeen();
 			const seqMeta = combinedPending();
+			// A non-empty block-seq appearing in key position (without `?`
+			// explicit-key indicator) means the parser produced a structure
+			// where a sequence is being treated as a key — that's invalid in
+			// block context. Empty block-seqs are placeholders the parser
+			// sometimes emits and should be ignored.
+			if (!afterValueSep && pendingExplicitKeyCol < 0 && child.length > 0) {
+				const lc = lineCol(state.text, child.offset);
+				state.errors.push(
+					new YamlErrorDetail({
+						code: "InvalidIndentation",
+						message: "Sequence in mapping key position",
+						offset: child.offset,
+						length: child.length,
+						line: lc.line,
+						column: lc.column,
+					}),
+				);
+			}
 			const seq = composeBlockSeq(child, state, hasMeta(seqMeta) ? seqMeta : undefined);
 			resetAllMeta();
 			pushNode(seq);
@@ -3187,6 +3279,25 @@ function composeDocument(
 			// Check if next meaningful child is a block-map (this scalar is a key)
 			const nextContent = findNextContentChild(children, i + 1);
 			if (nextContent && nextContent.type === "block-map") {
+				// A mapping cannot start on the `---` line. The `---` directive end
+				// is followed by a single value (or anchor+value), but a mapping
+				// pattern (key:) on the same line as `---` is malformed (9KBC, CXX2).
+				if (hasDocStart) {
+					const docStartChild = children.find((c) => c.type === "whitespace" && c.source === "---");
+					if (docStartChild && sameLine(state.text, docStartChild.offset, child.offset)) {
+						const lc = lineCol(state.text, child.offset);
+						state.errors.push(
+							new YamlErrorDetail({
+								code: "UnexpectedToken",
+								message: "Mapping cannot start on document-start (---) line",
+								offset: child.offset,
+								length: child.length,
+								line: lc.line,
+								column: lc.column,
+							}),
+						);
+					}
+				}
 				// Resolve which meta attaches to the root map vs. the first key.
 				// - If outer meta exists (collected across a newline), it belongs to
 				//   the map. The current `meta` belongs to the key.
@@ -3260,7 +3371,13 @@ function composeDocument(
 						const isTrailing =
 							(nextContent.type === "flow-scalar" &&
 								hasValueSepAfter(children, indexOfChild(children, nextContent) + 1)) ||
-							nextContent.type === "block-map";
+							nextContent.type === "block-map" ||
+							// Also catch: flow-scalar followed by a block-map sibling
+							// (the scalar+block-map pattern that forms an implicit mapping).
+							// Without this, 2CMS slips through after `hasBlockMapAfterInList`
+							// stops the merge before reaching the trailing scalar.
+							(nextContent.type === "flow-scalar" &&
+								hasBlockMapAfterInList(children, indexOfChild(children, nextContent) + 1));
 						if (isTrailing) {
 							const lc = lineCol(state.text, nextContent.offset);
 							state.errors.push(
@@ -3856,7 +3973,8 @@ export function parseDocument(
 					e.code === "AliasCountExceeded" ||
 					e.code === "UnexpectedToken" ||
 					e.code === "InvalidDirective" ||
-					e.code === "MalformedFlowCollection",
+					e.code === "MalformedFlowCollection" ||
+					e.code === "InvalidIndentation",
 			);
 			if (fatalErrors.length > 0) {
 				return Effect.fail(new YamlComposerError({ errors: fatalErrors, text }));
@@ -3930,7 +4048,8 @@ export function parseAllDocuments(
 						e.code === "DuplicateAnchor" ||
 						e.code === "AliasCountExceeded" ||
 						e.code === "UnexpectedToken" ||
-						e.code === "InvalidDirective",
+						e.code === "InvalidDirective" ||
+						e.code === "InvalidIndentation",
 				);
 				if (fatal.length > 0) fatalErrors.push(...fatal);
 			}

--- a/src/utils/composer.ts
+++ b/src/utils/composer.ts
@@ -4160,7 +4160,8 @@ export function composeDocumentFromCst(
 			e.code === "AliasCountExceeded" ||
 			e.code === "UnexpectedToken" ||
 			e.code === "InvalidDirective" ||
-			e.code === "MalformedFlowCollection",
+			e.code === "MalformedFlowCollection" ||
+			e.code === "InvalidIndentation",
 	);
 	if (fatalErrors.length > 0) {
 		return Effect.fail(new YamlComposerError({ errors: fatalErrors, text }));

--- a/src/utils/lexer.ts
+++ b/src/utils/lexer.ts
@@ -1231,6 +1231,12 @@ export function createScanner(text: string): YamlScanner {
 			const sLine = line;
 			const sCol = col;
 			advance();
+			// Comma is only valid as an item separator inside flow context.
+			// Outside flow ({...}/[...]), a stand-alone comma is malformed input —
+			// e.g., U99R `!!str, xxx` where the comma trails a tag.
+			if (flowDepth === 0) {
+				return makeToken("error", ",", start, sLine, sCol);
+			}
 			return makeToken("flow-separator", ",", start, sLine, sCol);
 		}
 


### PR DESCRIPTION
## Summary

Raises raw YAML 1.2 test-suite compliance from **97.93% → 98.27%** (+8 tests) by rejecting input previously parsed into structurally degenerate values. No public API changes — all changes are internal validation tightening.

## Tests now correctly rejecting invalid YAML

- **DMG6, EW3V, N4JP, U44R** — block-mapping keys at columns mismatching the established sibling-key column
- **ZVH3** — nested block sequence in mapping-key position rather than as a sibling sequence entry
- **9KBC, CXX2** — mapping pattern (`key: value`) opening on the same line as the `---` document-start marker
- **U99R** — stray comma in block (non-flow) context, e.g. inside a tag handle expression

## Implementation notes

**Composer (`src/utils/composer.ts`):**
- New helpers: `validateKeyColumn`, `hasBlockMapAfterInList`
- New state in `flattenBlockMapChildren`: `pendingExplicitKeyCol` (tracks `?` column for entry-indent), `hasExternalKeyColumn` (gates validation to avoid false positives from malformed CSTs)
- Multi-line plain scalar collector now stops at scalars followed by a sibling block-map (catches EW3V) and applies a `minContinuationColumn` floor to non-directive nodes (catches ZVH3 without breaking AB8U)
- Block-seq-in-key-position rejection (catches ZVH3)
- Document-start line mapping rejection (catches 9KBC, CXX2)
- Trailing-content detection in scalar root extended to scalar+block-map sibling pattern (preserves 2CMS rejection after the multi-line collector stops earlier)
- `InvalidIndentation` added to all three fatal-error filters

**Lexer (`src/utils/lexer.ts`):**
- Comma at `flowDepth === 0` now emits an `error` token instead of `flow-separator` (catches U99R)

## Behavioral note for users

`YamlComposerError.errors[].code` may now carry `\"InvalidIndentation\"` or `\"UnexpectedToken\"` at runtime — the public `YamlErrorCode` union already permitted these codes; only the runtime emission set has expanded. Code that relied on the lenient legacy behavior (e.g. parsing `key:\n wrong: 2` into `{ key: { ok: 1 }, \"\": null }`) will now error and may need to be updated.

## Test plan

- [x] All unit tests pass (`pnpm run test` — 1149 unit + 1198 e2e)
- [x] Raw compliance suite (`RAW_COMPLIANCE=1 pnpm run test:compliance-raw`) — 2382/2424 passing (was 2374/2424)
- [x] 8 entries removed from `XFAIL` skip-map; raw suite confirms each formerly-XFAIL test now correctly fails (rejects the invalid input)
- [x] No regressions in previously-passing tests, including KK5P (malformed CST tolerance) and AB8U (legitimate seq-entry continuation absorption)
- [x] `pnpm run typecheck` clean, `pnpm run lint` clean

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>