### PR TITLE
fix(parser): clear remaining 15 XFAIL fixtures via composer leniency

### DIFF
--- a/.changeset/strict-xfail-clear.md
+++ b/.changeset/strict-xfail-clear.md
@@ -1,0 +1,27 @@
+---
+"yaml-effect": patch
+---
+
+## Bug Fixes
+
+### Tighter rejection of malformed YAML
+
+Added composer-side structural validations that clear all 15 remaining XFAIL fixtures from the official yaml-test-suite. Raw spec compliance rises from 98.27% to 98.89% (2397/2424 assertions passing), and the XFAIL skip map is now empty.
+
+Inputs that the YAML 1.2 spec says should be rejected as invalid — but that previous releases silently accepted — now fail with `YamlComposerError`. The error channel and shape are unchanged, so downstream `Effect.catchTag("YamlComposerError", ...)` handlers see no difference; they simply receive more cases that were previously squeezed through as garbage data.
+
+Newly rejected cases:
+
+- Anchor or tag followed by a block-sequence `-` indicator on the same line (SY6V).
+- Anchor or tag in a map value's continuation line at column less than or equal to the parent key's column (G9HC, H7J7).
+- A stray `-` block-seq entry indicator at an indent shallower than its sibling sequence (4HVU).
+- Multi-line flow collection content whose continuation lines are not indented past the parent block (9C9N, VJP3/00).
+- A multi-line flow collection used as an implicit mapping key (C2SP).
+- A multi-line quoted scalar whose continuation lines are not indented past the parent key (QB6E).
+- A plain scalar that appears to continue across a comment line (BS4K).
+- A block scalar whose leading empty lines are more indented than the first content line (5LLU, S98Z, W9L4).
+- A scalar value carrying two separate anchor declarations (4JVG).
+- A tab character used as block indent after a value indicator on a continuation line (Y79Y/009).
+- A `!handle!suffix` reference in a document where no `%TAG` directive declares that handle, even when an earlier document in the same stream did (QLJ7).
+
+The composer now emits two error codes that previously appeared only on the parser channel: `TabIndentation` (Y79Y/009) and `UnresolvedTag` (QLJ7). These are listed in the `YamlComposerErrorCode` union and surface through `parse`, `parseDocument`, and `parseAllDocuments`.

--- a/.claude/design/yaml-effect/compliance-testing.md
+++ b/.claude/design/yaml-effect/compliance-testing.md
@@ -178,21 +178,21 @@ all test cases are relevant.
 ### XFAIL -- Expected Parse-Level Failures
 
 ```typescript
-export const XFAIL: Record<string, string> = { ... };
+export const XFAIL: Record<string, string> = {};
 ```
 
-Tests that run with `it.fails` -- the test is expected to fail. One
-remaining category of XFAIL entries:
+The XFAIL map is now empty. Both historical XFAIL categories --
+"Parser accepts invalid YAML" and "Parser rejects valid YAML" -- have
+been fully resolved.
 
-1. **Parser accepts invalid YAML** (15 tests) -- our parser succeeds on
-   input the spec says should be rejected. Missing validation for various
-   structural constraints (indentation, anchors, flow collection syntax).
-
-Previously there were also "parser rejects valid YAML" entries, but
-all 16 have been resolved through lexer, parser, and composer fixes
-(block scalar indentation, quoted scalar flow context, multi-line
-plain scalars, implicit block mapping indent tracking, explicit key
-handling).
+- "Parser rejects valid YAML" was cleared via lexer, parser, and
+  composer fixes (block scalar indentation, quoted scalar flow context,
+  multi-line plain scalars, implicit block mapping indent tracking,
+  explicit key handling).
+- "Parser accepts invalid YAML" was cleared in two passes of
+  composer-side structural-validation work (see "Key Compliance
+  Improvements (parser leniency)" and "Key Compliance Improvements
+  (parser leniency, second pass)" below).
 
 When an XFAIL test is marked with `it.fails`, Vitest expects the
 assertion to fail. If a code fix causes the test to start passing,
@@ -411,13 +411,13 @@ into per-category issues (#15, #16).
 | #10 | Add stricter validation for invalid YAML rejection | Closed (decomposed into #15, #16) |
 | #11 | Fix canonical output and roundtrip stringifier compliance | **Mostly resolved** (roundtrip 18->0, output 59->38) |
 | #15 | Parser rejects valid YAML | **Resolved** (0 remaining XFAIL "rejects valid") |
-| #16 | Parser accepts invalid YAML | Open (15 XFAIL "accepts invalid") |
+| #16 | Parser accepts invalid YAML | **Resolved** (0 remaining XFAIL "accepts invalid") |
 
-Current compliance: 2382/2424 raw assertions passing (98.27%), 1198
-filtered assertions passing, 15 XFAIL (all "accepts invalid"), 0 JSON
-comparison failures, 0 roundtrip failures, ~28 SKIP_ASSERTIONS entries
-(output only). Use `pnpm run test:compliance-raw` to see unfiltered
-results.
+Current compliance: 2397/2424 raw assertions passing (98.89%),
+filtered compliance has 0 XFAIL and 0 SKIP entries, 0 JSON comparison
+failures, 0 roundtrip failures, ~28 SKIP_ASSERTIONS entries (all
+canonical-output mismatches). Use `pnpm run test:compliance-raw` to
+see unfiltered results.
 
 Remaining canonical-output gaps cluster into a few categories:
 
@@ -712,6 +712,114 @@ Categories of fixes:
   `parseAllDocuments`, `composeDocumentFromCst`) so the new
   validation errors fail the parse Effect rather than being absorbed
   as warnings.
+
+### Key Compliance Improvements (parser leniency, second pass)
+
+The jump from 98.27% to 98.89% raw compliance (2397/2424 assertions,
++15 assertions) cleared the 15 remaining "parser accepts invalid
+YAML" XFAIL entries, bringing the XFAIL count to 0. All fixes are in
+`src/utils/composer.ts` (one shared helper plus eleven new
+validation paths). The skip map's `XFAIL` is now `{}`. Cleared
+fixtures: SY6V, G9HC, H7J7, 4HVU, 9C9N, VJP3/00, QB6E, C2SP, BS4K,
+4JVG, Y79Y/009, 5LLU, S98Z, W9L4, QLJ7. See
+[parsing.md](./parsing.md) "Structural Validation in
+`flattenBlockMapChildren`" plus the companion subsections (Composer
+Flow-Content Indent Validation, Anchor Before Sequence Dash on Same
+Line, Block Scalar Leading-Empty Validation, Multi-Line Implicit Keys
+(Flow Collections), Cross-Document Tag-Handle Validation) for the
+full helper-by-helper mechanics; this subsection is a fixture-by-
+fixture index.
+
+Categories of fixes (each item links a fixture to its
+parsing.md-documented helper):
+
+- **SY6V "Anchor before sequence entry on same line"** --
+  `validateAnchorTagNotFollowedBySeqDashOnSameLine` called from
+  `composeDocument`'s anchor/tag handlers. Skips empty `block-seq`
+  placeholders (length 0) when scanning forward.
+- **G9HC, H7J7 "Anchor/tag at parent column under map value"** --
+  `validatePropertyContinuationColumn` called from
+  `flattenBlockMapChildren` when handling anchor/tag children in
+  value position. The "parent key column" is computed via the new
+  shared helper `lineIndentColumn(text, offset)` (line's
+  leading-content column) rather than `lineCol(text, key.offset).column`,
+  which matters when a key has metadata before the scalar (e.g.
+  `!<tag> foo:` has line indent 0 but scalar offset col 25).
+- **4HVU "Wrong indentation in Sequence"** -- new detection in the
+  `-` whitespace handler of `flattenBlockMapChildren`: a stray `-`
+  outside any block-seq, on a continuation line, with no `?`
+  explicit-key context, is invalid. New helper
+  `precededByExplicitKeyMarker` allows the KK5P shape (`? - a`)
+  where the parser may include an empty block-seq placeholder or a
+  `?`-only block-map sentinel before the dash.
+- **9C9N, VJP3/00 "Flow content indentation"** -- `composeFlowMap`
+  and `composeFlowSeq` accept `parentBlockColumn?: number`, and the
+  new helper `validateFlowContentIndent` walks the source between
+  opener and end and rejects any continuation line whose first
+  non-whitespace column `<= parentBlockColumn`. Callers pass
+  `lastKeyColumn` (from `flattenBlockMapChildren`), `seqIndent`
+  (computed via `lineIndentColumn` from `composeBlockSeq`), or
+  `undefined` (`composeDocument` root, check skipped).
+- **QB6E "Wrong indented multiline quoted scalar"** --
+  `validateQuotedScalarContinuationIndent` called from
+  `flattenBlockMapChildren`'s flow-scalar branch when the style is
+  single-quoted or double-quoted and the scalar is in value
+  position. Continuation lines at column `<= parentKeyColumn` are
+  rejected.
+- **C2SP "Flow Mapping Key on two lines"** -- `checkMultilineImplicitKeys`
+  extended from scalar-only to flag `YamlMap` and `YamlSeq` keys
+  with `style === "flow"` whose source spans multiple lines.
+- **BS4K "Comment between plain scalar lines"** -- the
+  standalone-scalar branch of `composeDocument` now invokes
+  `checkTrailingContentAfterDocValue` even when `partsCount === 1`
+  (the multi-line merge stopped at a comment, leaving a single
+  line), so a subsequent flow-scalar across the comment is flagged
+  as trailing.
+- **4JVG "Scalar value with two anchors"** --
+  `validateNoDoubleAnchorOnScalar` called from
+  `flattenBlockMapChildren`'s flow-scalar / block-scalar branch.
+  When both `outerMeta.anchor` and `pendingMeta.anchor` are set AND
+  the scalar is not a key (no `:` after, no block-map sibling), the
+  helper emits `UnexpectedToken`.
+- **Y79Y/009 "Tab as block indentation after value indicator"** --
+  `validateNoTabAfterContinuationValueSep` called from the `:`
+  branch of `flattenBlockMapChildren`. When the `:` is at start of
+  line (col 0) AND followed by tab + same-line content, emits a
+  `TabIndentation` error. The fatal-error filter in `parseDocument`
+  was extended to include `TabIndentation`.
+- **5LLU, S98Z, W9L4 "Block scalar leading empties more indented than
+  first content line"** -- `validateBlockScalarLeadingEmpties` called
+  from `makeScalar` for block-literal / block-folded scalars.
+  Walks the raw source after the header; tracks indent of leading
+  whitespace-only lines; when the first non-empty content line is
+  found, rejects any preceding empty whose indent exceeds the
+  content indent. Per YAML 1.2 §8.1.1, `l-empty(n,c)` requires
+  `<= n` spaces.
+- **QLJ7 "Tag shorthand used in documents but only defined in the
+  first"** -- `validateCrossDocumentDirectives` extended: for every
+  doc index `>= 1` (regardless of directive presence),
+  `validateTagHandlesInDocument` builds the per-document handle set
+  from `%TAG` directives and walks all `tag` CST nodes, emitting
+  `UnresolvedTag` for any `!handle!suffix` whose handle is not
+  declared in the same document. Verbatim tags (`!<...>`),
+  `!!`-prefixed shorthands, and bare `!` are always valid.
+  `UnresolvedTag` was added to both `parseDocument` and
+  `parseAllDocuments` fatal-error filters.
+
+Shared helper introduced in this pass:
+
+- **`lineIndentColumn(text, offset)`** -- returns the column of the
+  first non-whitespace character on the line containing `offset`.
+  Used by `composeBlockMap` to compute `extKeyCol` from the
+  externally-passed first key (replacing the previous direct
+  `lineCol` call) and by `composeBlockSeq` to compute `seqIndent`
+  for passing to the flow composers. Necessary because a key with
+  metadata before the scalar (e.g. `!<tag> foo:`) has scalar offset
+  col != line indent col, and the relevant column for indentation
+  comparison is the line indent.
+
+Files changed in this pass: `src/utils/composer.ts` (+543 / -45)
+and `__test__/utils/yaml-test-suite-skip-map.ts` (XFAIL is now `{}`).
 
 ### Dual Block Scalar Decoders
 

--- a/.claude/design/yaml-effect/errors.md
+++ b/.claude/design/yaml-effect/errors.md
@@ -172,16 +172,28 @@ class YamlErrorDetail extends Schema.Class("YamlErrorDetail")({
 
 `UndefinedAlias`, `DuplicateAnchor`, `CircularAlias`, `UnresolvedTag`,
 `InvalidTagValue`, `AliasCountExceeded`, `InvalidIndentation`,
-`UnexpectedToken`.
+`UnexpectedToken`, `TabIndentation`.
 
-The composer reuses the `InvalidIndentation` and `UnexpectedToken` codes
-from the parser-error vocabulary for structural-validation errors raised
-during composition (key-column mismatches, block-seq in key position,
-mapping starting on the document-start line). These errors are produced
-by the composer's leniency-validation helpers (see
-[parsing.md](./parsing.md) "Structural Validation in `flattenBlockMapChildren`")
-but are reported on the `YamlComposerError` channel because the composer
-is the layer that detects them.
+The composer reuses `InvalidIndentation`, `UnexpectedToken`, and
+`TabIndentation` from the parser-error vocabulary for
+structural-validation errors raised during composition (key-column
+mismatches, block-seq in key position, mapping starting on the
+document-start line, anchor/tag at parent column under a map value,
+stray block-seq entry on a continuation line, multi-line flow keys,
+quoted-scalar continuation indent below the parent key, double anchors
+on a non-key scalar, anchor before a sequence dash on the same line,
+block-scalar leading empties more indented than the first content
+line, comment between plain scalar lines, and tab after a
+continuation-line value indicator). `UnresolvedTag` is also raised
+by the cross-document tag-handle check when a `!handle!suffix`
+references a `%TAG` directive declared only in a different document
+of the same stream. These errors are produced by the composer's
+leniency-validation helpers (see [parsing.md](./parsing.md)
+"Structural Validation in `flattenBlockMapChildren`" plus the
+companion subsections for flow-content indent, block-scalar
+leading-empties, multi-line implicit keys, and cross-document
+tag-handle validation) but are reported on the `YamlComposerError`
+channel because the composer is the layer that detects them.
 
 ## Error-to-Function Mapping
 

--- a/.claude/design/yaml-effect/parsing.md
+++ b/.claude/design/yaml-effect/parsing.md
@@ -299,8 +299,22 @@ structure. State and helpers:
   `hasExternalKeyColumn` is true.
 - `pushNode` -- before tracking `lastKeyColumn`, resolves the entry
   indent from `pendingExplicitKeyCol` if a `?` was just consumed.
+- `precededByExplicitKeyMarker(children, idx)` -- returns true if any
+  of the immediately preceding non-trivia siblings is a `?` indicator
+  or an empty block-seq placeholder (length 0) or a `?`-only block-map
+  sentinel. Used by the stray-dash check to allow KK5P-style explicit
+  keys (`? - a`) where the parser shape includes such placeholders.
+- `lineIndentColumn(text, offset)` (shared helper) -- returns the
+  column of the first non-whitespace character on the line containing
+  `offset`. Used in place of `lineCol(text, offset).column` whenever
+  the relevant column is the line's leading-content column rather than
+  the offset's own column. This matters when a key has metadata
+  before the scalar (e.g. `!<tag> foo:` has line-indent 0 but the
+  scalar's offset column is 25); the key's effective indent is the
+  metadata column, not the scalar column. `composeBlockMap` uses this
+  helper to compute `extKeyCol` from the externally-passed first key.
 
-Validation is applied at three points:
+Validation is applied at the following points:
 
 1. **Scalar+block-map first-key path** -- when a scalar is in key
    position and is followed by a block-map sibling (the implicit
@@ -316,6 +330,40 @@ Validation is applied at three points:
    `hasDocumentStart` is true **and** the scalar is on the same line
    as `---`, the composer emits `UnexpectedToken` "Mapping cannot
    start on document-start (---) line". Catches 9KBC and CXX2.
+4. **Property continuation column** -- `validatePropertyContinuationColumn`
+   is called from the anchor/tag handler when a property (anchor or
+   tag) appears in value position. If the property is on a continuation
+   line (not the same line as the introducing `:`), its column must
+   be strictly greater than `parentKeyColumn` (computed via
+   `lineIndentColumn` so it accounts for metadata-before-scalar
+   keys). Catches G9HC and H7J7 (anchor/tag at parent column under
+   a map value).
+5. **Stray block-seq entry on continuation line** -- in the `-`
+   whitespace handler, a stray `-` outside any block-seq, on a
+   continuation line, with no `?`-explicit-key context (checked via
+   `precededByExplicitKeyMarker`), emits `InvalidIndentation`.
+   Catches 4HVU ("Wrong indentation in Sequence").
+6. **Quoted scalar continuation indent** --
+   `validateQuotedScalarContinuationIndent` runs from the flow-scalar
+   branch when the scalar's style is `single-quoted` or `double-quoted`
+   and the scalar is in value position. Continuation lines whose first
+   non-whitespace column is `<= parentKeyColumn` produce
+   `InvalidIndentation`. Catches QB6E (multi-line quoted value indented
+   at or below the key column).
+7. **No tab after continuation value-sep** --
+   `validateNoTabAfterContinuationValueSep` runs from the `:` branch.
+   When the `:` is at column 0 (start of a continuation line) AND
+   followed by a tab plus same-line content, the helper emits a
+   `TabIndentation` error. The fatal-error filter in `parseDocument`
+   was extended to include `TabIndentation` so this fails the parse.
+   Catches Y79Y/009 (tab as block indentation after a value indicator).
+8. **No double anchor on a non-key scalar** --
+   `validateNoDoubleAnchorOnScalar` runs from the flow-scalar /
+   block-scalar branch. When both `outerMeta.anchor` and
+   `pendingMeta.anchor` are set AND the scalar is not a key (no
+   following `:` value-sep, no following block-map sibling), the
+   helper emits `UnexpectedToken`. Catches 4JVG (a single scalar
+   value carrying two anchors).
 
 ### Trailing-Content Detection in Scalar Root
 
@@ -326,10 +374,91 @@ sibling patterns (using `hasBlockMapAfterInList`), preserving the 2CMS
 rejection that previously relied on the multi-line merge consuming
 the "invalid" continuation.
 
+The standalone-scalar branch of `composeDocument` extends this check
+to the `partsCount === 1` case as well: when
+`collectMultilinePlainScalar` stops because of an intervening comment
+(leaving a single line in `parts`), `checkTrailingContentAfterDocValue`
+is still invoked so a subsequent flow-scalar across the comment is
+flagged as trailing. Catches BS4K (comment between plain scalar lines
+that would otherwise look like a single value).
+
 `InvalidIndentation` is included in all three fatal-error filters
 (`parseDocument`, `parseAllDocuments`, `composeDocumentFromCst`) so
 that these structural-validation errors fail the parse Effect rather
-than being absorbed as warnings.
+than being absorbed as warnings. `TabIndentation` and `UnresolvedTag`
+were added to both the `parseDocument` and `parseAllDocuments` filters
+so that a tab used as block indent after a continuation-line value
+indicator (Y79Y/009) and a `!handle!suffix` whose handle is not
+declared in the same document (QLJ7) are fatal at either entry point.
+`composeDocumentFromCst` keeps the narrower filter
+(`InvalidIndentation` only) because it is the low-level entry point
+used by visitors and other consumers that should not fail on these
+higher-level structural rejections.
+
+### Composer Flow-Content Indent Validation
+
+`composeFlowMap` and `composeFlowSeq` accept an optional
+`parentBlockColumn?: number` parameter. When set, the new helper
+`validateFlowContentIndent` walks the source text between the flow
+opener (`{` or `[`) and the closing bracket and rejects any
+continuation line whose first non-whitespace column is
+`<= parentBlockColumn`. Per YAML 1.2 §7.4, flow content nested under
+a block context must be more indented than its parent block.
+
+Callers pass:
+
+- `lastKeyColumn` from `flattenBlockMapChildren` (when a flow
+  collection appears in value position under a block mapping)
+- `seqIndent` (computed via `lineIndentColumn`) from `composeBlockSeq`
+  (when a flow collection appears as a block-seq entry)
+- `undefined` from `composeDocument` at root level (no parent block,
+  so the check is skipped)
+
+Catches 9C9N and VJP3/00 ("Flow content indentation").
+
+### Anchor Before Sequence Dash on Same Line
+
+`composeDocument`'s anchor/tag handlers call
+`validateAnchorTagNotFollowedBySeqDashOnSameLine`. The helper scans
+forward through the children looking for a `block-seq` whose first
+entry begins on the same source line as the just-seen anchor or tag.
+Empty `block-seq` placeholders (length 0) are skipped during the
+forward scan because they do not represent actual content. When a
+real same-line `-` is found, the composer emits `UnexpectedToken`.
+Catches SY6V ("Anchor before sequence entry on same line").
+
+### Block Scalar Leading-Empty Validation
+
+`makeScalar()` calls `validateBlockScalarLeadingEmpties` for
+block-literal and block-folded scalars. The helper walks the raw
+source after the header line, tracks the indent of leading
+whitespace-only lines, then -- when the first non-empty content line
+is found -- rejects any preceding empty whose indent exceeds the
+content indent. Per YAML 1.2 §8.1.1, `l-empty(n,c)` requires `<= n`
+spaces, so a leading blank line that is more indented than the
+first real content line is invalid. Catches 5LLU, S98Z, and W9L4.
+
+### Multi-Line Implicit Keys (Flow Collections)
+
+The existing `checkMultilineImplicitKeys` helper -- which previously
+only flagged scalar keys whose source spans multiple lines -- was
+extended to cover `YamlMap` and `YamlSeq` keys with `style === "flow"`
+whose source spans multiple lines. A flow collection used as an
+implicit mapping key must fit on a single line. Catches C2SP ("Flow
+mapping key on two lines").
+
+### Cross-Document Tag-Handle Validation
+
+`validateCrossDocumentDirectives` was extended: for every document
+index `>= 1` (regardless of whether that document declares its own
+directives), the new `validateTagHandlesInDocument` helper walks
+the document's CST. It builds the per-document handle set from
+`%TAG` directives, then walks all `tag` CST nodes and emits
+`UnresolvedTag` for any `!handle!suffix` whose handle is not declared
+in this same document. Verbatim tags (`!<...>`), `!!`-prefixed
+shorthands, and bare `!` are always considered valid. Catches QLJ7
+("Tag shorthand used in documents but only defined in the first
+document").
 
 ### Anchor/Alias Handling
 
@@ -435,11 +564,16 @@ Composition errors produce `YamlComposerError` containing:
 
 Error codes: `UndefinedAlias`, `DuplicateAnchor`, `CircularAlias`,
 `UnresolvedTag`, `InvalidTagValue`, `AliasCountExceeded`,
-`InvalidIndentation`, `UnexpectedToken`. The latter two are produced
-by the structural-validation paths in `flattenBlockMapChildren` and
+`InvalidIndentation`, `UnexpectedToken`, `TabIndentation`. The
+indentation, token, and tab-indentation codes are produced by the
+structural-validation paths in `flattenBlockMapChildren` and
 `composeDocument` (see "Structural Validation in
 `flattenBlockMapChildren`" above) and are reported on the
 `YamlComposerError` channel rather than `YamlParseError`.
+`UnresolvedTag` is also produced by the cross-document tag-handle
+check (`validateTagHandlesInDocument`) when a `!handle!suffix` tag
+references a `%TAG` handle that was only declared in a different
+document of the same stream.
 
 ### Block Scalar Decoding
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,11 @@ If you just need to parse YAML into a JavaScript object, use [yaml](https://www.
 This library is for Effect-based programs that need deeper introspection and manipulation of YAML documents: typed parse errors you can `catchTag`, Schema pipelines that validate YAML strings into domain types, AST and CST access, non-destructive formatting and path-based modification, semantic equality comparisons, and SAX-style visitor streams that are composable in Effect pipelines.
 
 > **Note:** yaml-effect is new and may introduce breaking changes before a
-> 1.0.0 release. We are actively working toward full YAML 1.2 spec
-> compliance. The library is validated against the official
-> [yaml-test-suite](https://github.com/yaml/yaml-test-suite) — our current
-> compliance is tracked in the badge above. The parser handles common YAML
-> well, but edge cases around tab handling, complex mapping keys, and strict
-> error rejection are still being addressed.
+> 1.0.0 release. The library is validated against the official
+> [yaml-test-suite](https://github.com/yaml/yaml-test-suite) — current
+> compliance is tracked in the badge above. A small number of canonical
+> stringifier output cases (explicit `?` syntax for complex keys, multi-doc
+> `...` end markers) are still being addressed.
 
 ## Installation
 

--- a/__test__/utils/yaml-test-suite-skip-map.ts
+++ b/__test__/utils/yaml-test-suite-skip-map.ts
@@ -25,24 +25,7 @@
 export const SKIP: Record<string, string> = {};
 
 /** Tests expected to fail at parse level — known gaps to fix later. */
-export const XFAIL: Record<string, string> = {
-	// Parser accepts invalid YAML (15)
-	"4HVU": "Parser accepts invalid YAML: Wrong indendation in Sequence",
-	"4JVG": "Parser accepts invalid YAML: Scalar value with two anchors",
-	"5LLU": "Parser accepts invalid YAML: Block scalar with wrong indented line after spaces only",
-	"9C9N": "Parser accepts invalid YAML: Wrong indented flow sequence",
-	BS4K: "Parser accepts invalid YAML: Comment between plain scalar lines",
-	C2SP: "Parser accepts invalid YAML: Flow Mapping Key on two lines",
-	G9HC: "Parser accepts invalid YAML: Invalid anchor in zero indented sequence",
-	H7J7: "Parser accepts invalid YAML: Node anchor not indented",
-	QB6E: "Parser accepts invalid YAML: Wrong indented multiline quoted scalar",
-	QLJ7: "Parser accepts invalid YAML: Tag shorthand used in documents but only defined in the first",
-	S98Z: "Parser accepts invalid YAML: Block scalar with more spaces than first content line",
-	SY6V: "Parser accepts invalid YAML: Anchor before sequence entry on same line",
-	"VJP3/00": "Parser accepts invalid YAML: Flow collections over many lines",
-	W9L4: "Parser accepts invalid YAML: Literal block scalar with more spaces in first line",
-	"Y79Y/009": "Parser accepts invalid YAML: Tab as block indentation after value indicator",
-};
+export const XFAIL: Record<string, string> = {};
 
 /**
  * Tests to skip specific assertions for.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -81,6 +81,9 @@ information.
 | `UnresolvedTag` | Explicit tag cannot be resolved |
 | `InvalidTagValue` | Value does not match its explicit tag |
 | `AliasCountExceeded` | Alias count exceeds `maxAliasCount` |
+| `InvalidIndentation` | Key column or block-seq position violates indentation rules |
+| `TabIndentation` | Tab used for indentation (YAML 1.2 forbids this) |
+| `UnexpectedToken` | Mapping starts on the document-start (`---`) line, or other structural violation |
 
 ## Handling Errors with `Effect.catchTag`
 
@@ -173,7 +176,9 @@ malformed flow collections).
 ### `YamlComposerError`
 
 Raised when AST composition encounters semantic errors (undefined aliases,
-duplicate anchors, alias count exceeded).
+duplicate anchors, alias count exceeded) or structural-validation errors
+detected during composition (key-column indentation mismatches, block-seq
+in key position, mapping content on the document-start line).
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -286,6 +286,9 @@ Effect.runSync(program);
 | `UnresolvedTag` | Explicit tag cannot be resolved |
 | `InvalidTagValue` | Value does not match its explicit tag |
 | `AliasCountExceeded` | Too many aliases (exceeds `maxAliasCount`) |
+| `InvalidIndentation` | Key column or block-seq position violates indentation rules |
+| `TabIndentation` | Tab character used where indentation must use spaces |
+| `UnexpectedToken` | Mapping starts on the document-start (`---`) line, or other structural violation |
 
 When `uniqueKeys` is `true` (the default), duplicate key warnings are promoted
 to errors via `YamlComposerError`.

--- a/src/utils/composer.ts
+++ b/src/utils/composer.ts
@@ -1116,6 +1116,11 @@ interface NodeMeta {
 
 function makeScalar(cst: CstNode, state: ComposerState, meta?: NodeMeta): YamlScalar {
 	const style = getScalarStyle(cst);
+	if (style === "block-literal" || style === "block-folded") {
+		// 5LLU, S98Z, W9L4: leading empty lines in a block scalar must not be
+		// indented beyond the first content line's indent.
+		validateBlockScalarLeadingEmpties(cst, state);
+	}
 	const rawValue = getScalarValue(cst, state.text);
 	const value = resolveScalar(rawValue, style, meta?.tag, state);
 	const chomp = getBlockChomp(cst);
@@ -1310,10 +1315,15 @@ function composeBlockMap(
 	const children = blockMapCst.children ?? [];
 	const pairs: YamlPair[] = [];
 
-	// Phase 1: parse children into a flat stream of semantic items
+	// Phase 1: parse children into a flat stream of semantic items.
+	// The key's "effective column" for indentation purposes is the leftmost
+	// non-whitespace column on the line containing the key — properties (tags,
+	// anchors) before the scalar can shift the actual scalar offset to a
+	// larger column, but the property column is what matters for validating
+	// continuation-line indentation.
 	const extKeyOffset =
 		externalFirstKey && "offset" in externalFirstKey ? (externalFirstKey as YamlScalar).offset : undefined;
-	const extKeyCol = extKeyOffset !== undefined ? lineCol(state.text, extKeyOffset).column : undefined;
+	const extKeyCol = extKeyOffset !== undefined ? lineIndentColumn(state.text, extKeyOffset) : undefined;
 	const items = flattenBlockMapChildren(children, state, extKeyCol, extKeyOffset);
 
 	// If there's an external first key, prepend it
@@ -1493,6 +1503,10 @@ function flattenBlockMapChildren(
 				continue;
 			}
 			if (child.source === ":") {
+				// Y79Y/009: a value-sep `:` on a continuation line followed by a
+				// tab and same-line content is invalid — tabs cannot serve as the
+				// indent for the upcoming key/value content (YAML 1.2 §6.1).
+				validateNoTabAfterContinuationValueSep(child, children, i, state);
 				// Flush pending tag/anchor as empty scalar before value-sep.
 				// Combine outer+pending so any anchors before a newline are also
 				// represented (otherwise outer-context anchors would be lost).
@@ -1535,6 +1549,31 @@ function flattenBlockMapChildren(
 						column: lc.column,
 					}),
 				);
+			} else if (
+				// 4HVU: a stray block-seq entry indicator "-" outside any block-seq
+				// (e.g. after a sibling block-seq value at a different indent) is
+				// malformed. Legitimate "-" indicators are consumed by composeBlockSeq.
+				// Allow "-" after a `?` explicit-key indicator (KK5P: `? - a`),
+				// detected via either pendingExplicitKeyCol being set OR the
+				// preceding non-trivia child being an empty block-seq placeholder
+				// or a `?`-marker block-map (KK5P parser shape for `? - a`).
+				child.source === "-" &&
+				lastValueSepOffset >= 0 &&
+				!sameLine(state.text, lastValueSepOffset, child.offset) &&
+				pendingExplicitKeyCol < 0 &&
+				!precededByExplicitKeyMarker(children, i)
+			) {
+				const lc = lineCol(state.text, child.offset);
+				state.errors.push(
+					new YamlErrorDetail({
+						code: "InvalidIndentation",
+						message: "Block sequence entry indicator outside any sequence",
+						offset: child.offset,
+						length: child.length,
+						line: lc.line,
+						column: lc.column,
+					}),
+				);
 			}
 			continue;
 		}
@@ -1544,6 +1583,11 @@ function flattenBlockMapChildren(
 			continue;
 		}
 		if (child.type === "anchor") {
+			// G9HC, H7J7: anchor/tag in value position on a continuation line
+			// (different line from the `:` indicator) must be at a column
+			// strictly greater than the parent key's column. Per YAML 1.2 §8.1.2,
+			// properties before a block collection must be at indent n+1.
+			validatePropertyContinuationColumn(child, state, afterValueSep, lastValueSepOffset, lastKeyColumn);
 			// If we already have pending meta and a newline was seen since, the
 			// existing pending meta belongs to the outer container (it was on the
 			// same line as the value indicator). Move it to outerMeta so the new
@@ -1553,6 +1597,7 @@ function flattenBlockMapChildren(
 			continue;
 		}
 		if (child.type === "tag") {
+			validatePropertyContinuationColumn(child, state, afterValueSep, lastValueSepOffset, lastKeyColumn);
 			commitOuterIfNewlineSeen();
 			pendingMeta.tag = child.source;
 			continue;
@@ -1561,6 +1606,11 @@ function flattenBlockMapChildren(
 			// Reaching content: if pending meta predates a newline, it belongs to
 			// the outer container, not the upcoming inner content.
 			commitOuterIfNewlineSeen();
+			// 4JVG: a single scalar cannot have two anchor declarations. When
+			// outerMeta and pendingMeta both have anchors AND the scalar is
+			// neither a key nor produces a nested map (no block-map sibling and
+			// no following `:`), both anchors collapse onto the scalar — invalid.
+			validateNoDoubleAnchorOnScalar(child, children, i, outerMeta, pendingMeta, state);
 			// If this scalar is a key (followed by `:` at this level) and there's
 			// pending meta from a previous VALUE position, flush it as a null value.
 			// e.g., `a: &anchor\nb:` — the anchor belongs to null, not to `b`.
@@ -1845,6 +1895,9 @@ function flattenBlockMapChildren(
 
 			if (isValuePosition && (style === "single-quoted" || style === "double-quoted")) {
 				checkTrailingContentOnSameLine(children, i + 1, child, state);
+				// QB6E: multi-line quoted scalar continuation must be indented past
+				// the parent key column.
+				validateQuotedScalarContinuationIndent(child, state, lastKeyColumn);
 			}
 			continue;
 		}
@@ -1934,7 +1987,7 @@ function flattenBlockMapChildren(
 			commitOuterIfNewlineSeen();
 			const isValue = afterValueSep;
 			const flowMapMeta = combinedPending();
-			const map = composeFlowMap(child, state, hasMeta(flowMapMeta) ? flowMapMeta : undefined);
+			const map = composeFlowMap(child, state, hasMeta(flowMapMeta) ? flowMapMeta : undefined, lastKeyColumn);
 			resetAllMeta();
 			pushNode(map);
 			if (isValue) checkTrailingContentOnSameLine(children, i + 1, child, state);
@@ -1944,7 +1997,7 @@ function flattenBlockMapChildren(
 			commitOuterIfNewlineSeen();
 			const isValue = afterValueSep;
 			const flowSeqMeta = combinedPending();
-			const seq = composeFlowSeq(child, state, hasMeta(flowSeqMeta) ? flowSeqMeta : undefined);
+			const seq = composeFlowSeq(child, state, hasMeta(flowSeqMeta) ? flowSeqMeta : undefined, lastKeyColumn);
 			resetAllMeta();
 			pushNode(seq);
 			if (isValue) checkTrailingContentOnSameLine(children, i + 1, child, state);
@@ -2240,23 +2293,45 @@ function checkMultilineImplicitKeys(
 	// CST spans and explicit keys (?) are allowed to be multiline.
 	for (const pair of pairs) {
 		const key = pair.key;
-		if (key._tag !== "YamlScalar") continue;
 		if (key.length === 0) continue; // synthetic null key
-		const s = key.style;
-		if (s !== "single-quoted" && s !== "double-quoted") continue;
-		const keySource = state.text.slice(key.offset, key.offset + key.length);
-		if (keySource.includes("\n") || keySource.includes("\r")) {
-			const lc = lineCol(state.text, key.offset);
-			state.errors.push(
-				new YamlErrorDetail({
-					code: "UnexpectedToken",
-					message: "Implicit mapping key must not span multiple lines",
-					offset: key.offset,
-					length: key.length,
-					line: lc.line,
-					column: lc.column,
-				}),
-			);
+		// Quoted scalars: check the source span for newlines.
+		if (key._tag === "YamlScalar") {
+			const s = key.style;
+			if (s !== "single-quoted" && s !== "double-quoted") continue;
+			const keySource = state.text.slice(key.offset, key.offset + key.length);
+			if (keySource.includes("\n") || keySource.includes("\r")) {
+				const lc = lineCol(state.text, key.offset);
+				state.errors.push(
+					new YamlErrorDetail({
+						code: "UnexpectedToken",
+						message: "Implicit mapping key must not span multiple lines",
+						offset: key.offset,
+						length: key.length,
+						line: lc.line,
+						column: lc.column,
+					}),
+				);
+			}
+			continue;
+		}
+		// Flow collections (YamlMap/YamlSeq with style=flow) cannot be used as
+		// implicit keys when their source spans multiple lines (C2SP).
+		if (key._tag === "YamlMap" || key._tag === "YamlSeq") {
+			if (key.style !== "flow") continue;
+			const keySource = state.text.slice(key.offset, key.offset + key.length);
+			if (keySource.includes("\n") || keySource.includes("\r")) {
+				const lc = lineCol(state.text, key.offset);
+				state.errors.push(
+					new YamlErrorDetail({
+						code: "UnexpectedToken",
+						message: "Implicit mapping key must not span multiple lines",
+						offset: key.offset,
+						length: key.length,
+						line: lc.line,
+						column: lc.column,
+					}),
+				);
+			}
 		}
 	}
 
@@ -2419,6 +2494,347 @@ function sameLine(text: string, offsetA: number, offsetB: number): boolean {
 }
 
 /**
+ * Returns the column of the first non-whitespace character on the line
+ * containing the given offset. Used to compute the "effective" indent of a
+ * line when properties (tag/anchor) precede the actual content scalar —
+ * the indent is the leftmost column on the line, not the scalar's column.
+ */
+function lineIndentColumn(text: string, offset: number): number {
+	let lineStart = offset;
+	while (lineStart > 0 && text[lineStart - 1] !== "\n") lineStart--;
+	let i = lineStart;
+	while (i < text.length && (text[i] === " " || text[i] === "\t")) i++;
+	return i - lineStart;
+}
+
+/**
+ * 5LLU, S98Z, W9L4: per YAML 1.2 §8.1.1, leading empty lines preceding the
+ * first content line in a block scalar must satisfy l-empty(n,c) — at most
+ * n leading spaces, where n is the content indent. When the indent indicator
+ * is auto-detected from the first non-empty line, that line establishes n;
+ * any preceding empty line with more than n spaces is malformed.
+ */
+function validateBlockScalarLeadingEmpties(cst: CstNode, state: ComposerState): void {
+	const raw = cst.source;
+	let i = 0;
+	// Skip header line (e.g. ">", "|", "|+2", etc.)
+	while (i < raw.length && raw[i] !== "\n" && raw[i] !== "\r") i++;
+	if (i < raw.length) {
+		if (raw[i] === "\r" && raw[i + 1] === "\n") i += 2;
+		else i++;
+	}
+	// Walk lines, tracking offsets of leading-empty lines and their indent.
+	const emptyIndents: { indent: number; offsetInRaw: number }[] = [];
+	while (i < raw.length) {
+		const lineStart = i;
+		let spaces = 0;
+		while (i < raw.length && raw[i] === " ") {
+			spaces++;
+			i++;
+		}
+		if (i >= raw.length || raw[i] === "\n" || raw[i] === "\r") {
+			// Empty (whitespace-only) line.
+			emptyIndents.push({ indent: spaces, offsetInRaw: lineStart });
+			if (i < raw.length) {
+				if (raw[i] === "\r" && raw[i + 1] === "\n") i += 2;
+				else i++;
+			}
+			continue;
+		}
+		// First non-empty line found.
+		const contentIndent = spaces;
+		for (const empty of emptyIndents) {
+			if (empty.indent > contentIndent) {
+				const offset = cst.offset + empty.offsetInRaw;
+				const lc = lineCol(state.text, offset);
+				state.errors.push(
+					new YamlErrorDetail({
+						code: "InvalidIndentation",
+						message: "Block scalar leading empty line cannot be more indented than the first content line",
+						offset,
+						length: empty.indent,
+						line: lc.line,
+						column: lc.column,
+					}),
+				);
+				return;
+			}
+		}
+		return;
+	}
+}
+
+/**
+ * QB6E: continuation lines of a multi-line quoted scalar in value position
+ * must be indented past the parent key column.
+ */
+function validateQuotedScalarContinuationIndent(scalar: CstNode, state: ComposerState, parentKeyColumn: number): void {
+	if (parentKeyColumn < 0) return;
+	const text = state.text;
+	const start = scalar.offset;
+	const end = scalar.offset + scalar.length;
+	let i = start;
+	let inLineStart = false;
+	let lineStart = -1;
+	while (i < end && i < text.length) {
+		const ch = text[i];
+		if (ch === "\n") {
+			inLineStart = true;
+			lineStart = i + 1;
+			i++;
+			continue;
+		}
+		if (inLineStart) {
+			if (ch === " " || ch === "\t") {
+				i++;
+				continue;
+			}
+			const col = i - lineStart;
+			if (col <= parentKeyColumn) {
+				const lc = lineCol(text, i);
+				state.errors.push(
+					new YamlErrorDetail({
+						code: "InvalidIndentation",
+						message: "Multi-line quoted scalar continuation must be indented past the parent key",
+						offset: i,
+						length: 1,
+						line: lc.line,
+						column: lc.column,
+					}),
+				);
+				return;
+			}
+			inLineStart = false;
+		}
+		i++;
+	}
+}
+
+/**
+ * 9C9N, VJP3/00: continuation lines of multi-line flow content must be
+ * indented past the parent block context. Caller passes the parent block
+ * column; for document-root flow content (no parent block) the caller
+ * omits it and the check is skipped.
+ */
+function validateFlowContentIndent(cst: CstNode, state: ComposerState, parentBlockColumn?: number): void {
+	if (parentBlockColumn === undefined || parentBlockColumn < 0) return;
+	const text = state.text;
+	const start = cst.offset;
+	const end = cst.offset + cst.length;
+	let i = start;
+	let inLineStart = false;
+	let lineStart = -1;
+	while (i < end && i < text.length) {
+		const ch = text[i];
+		if (ch === "\n") {
+			inLineStart = true;
+			lineStart = i + 1;
+			i++;
+			continue;
+		}
+		if (inLineStart) {
+			if (ch === " " || ch === "\t") {
+				i++;
+				continue;
+			}
+			const col = i - lineStart;
+			if (col <= parentBlockColumn) {
+				const lc = lineCol(text, i);
+				state.errors.push(
+					new YamlErrorDetail({
+						code: "InvalidIndentation",
+						message: "Flow content continuation line must be indented past the parent block",
+						offset: i,
+						length: 1,
+						line: lc.line,
+						column: lc.column,
+					}),
+				);
+				return;
+			}
+			inLineStart = false;
+		}
+		i++;
+	}
+}
+
+/**
+ * 4JVG: a single scalar cannot have two anchor declarations. When the
+ * outer-meta slot and the pending-meta slot both carry an anchor, AND the
+ * scalar is being consumed as a plain value (not as a key for a nested
+ * block-map, not followed by `:`), both anchors would collapse onto the
+ * scalar — that's invalid YAML.
+ */
+function validateNoDoubleAnchorOnScalar(
+	scalar: CstNode,
+	children: readonly CstNode[],
+	idx: number,
+	outerMeta: NodeMeta,
+	pendingMeta: NodeMeta,
+	state: ComposerState,
+): void {
+	if (outerMeta.anchor === undefined || pendingMeta.anchor === undefined) return;
+	// Skip when the scalar is a key (followed by `:` or by a block-map sibling).
+	if (hasValueSepAfterInList(children, idx + 1)) return;
+	const nextContent = findNextContentInList(children, idx + 1);
+	if (nextContent?.node.type === "block-map" && !hasValueSepBetween(children, idx + 1, nextContent.idx)) {
+		return;
+	}
+	const lc = lineCol(state.text, scalar.offset);
+	state.errors.push(
+		new YamlErrorDetail({
+			code: "UnexpectedToken",
+			message: "Scalar cannot have two anchor declarations",
+			offset: scalar.offset,
+			length: scalar.length,
+			line: lc.line,
+			column: lc.column,
+		}),
+	);
+}
+
+/**
+ * Y79Y/009: when a `:` value-sep is at the start of a line (continuation
+ * line, not on the same line as a key) and is immediately followed by a
+ * tab and same-line content, the tab is being used as block indentation
+ * for the upcoming content — invalid per YAML 1.2 §6.1.
+ */
+function validateNoTabAfterContinuationValueSep(
+	colonChild: CstNode,
+	children: readonly CstNode[],
+	idx: number,
+	state: ComposerState,
+): void {
+	// Only when `:` is the first non-whitespace on its line — this covers
+	// both column 0 (Y79Y/009) and nested mappings where the value indicator
+	// sits at the start of a continuation line at any indent.
+	const col = lineCol(state.text, colonChild.offset).column;
+	if (col !== lineIndentColumn(state.text, colonChild.offset)) return;
+	// Find the next non-whitespace child on the same line.
+	let sawTab = false;
+	for (let j = idx + 1; j < children.length; j++) {
+		const c = children[j];
+		if (!c) continue;
+		if (c.type === "newline") return;
+		if (c.type === "whitespace") {
+			if (c.source.includes("\t")) sawTab = true;
+			continue;
+		}
+		// Found a non-whitespace child — only flag if a tab was seen between.
+		if (sawTab && sameLine(state.text, colonChild.offset, c.offset)) {
+			const lc = lineCol(state.text, colonChild.offset);
+			state.errors.push(
+				new YamlErrorDetail({
+					code: "TabIndentation",
+					message: "Tab character cannot be used as indentation after a value indicator",
+					offset: colonChild.offset,
+					length: colonChild.length,
+					line: lc.line,
+					column: lc.column,
+				}),
+			);
+		}
+		return;
+	}
+}
+
+/**
+ * Returns true when the upcoming "-" indicator is preceded (after only
+ * whitespace/newlines) by either an empty block-seq placeholder or a
+ * `?`-only block-map. The parser uses both shapes to mark "explicit key
+ * with a sequence as the key" (KK5P fixture).
+ */
+function precededByExplicitKeyMarker(children: readonly CstNode[], idx: number): boolean {
+	for (let j = idx - 1; j >= 0; j--) {
+		const c = children[j];
+		if (!c) continue;
+		if (c.type === "whitespace" || c.type === "newline" || c.type === "comment") continue;
+		if (c.type === "block-seq" && c.length === 0) return true;
+		if (c.type === "block-map" && c.source.trimEnd() === "?") return true;
+		return false;
+	}
+	return false;
+}
+
+/**
+ * G9HC, H7J7: anchor/tag in value position on a continuation line (not on
+ * the same line as `:`) must be at a column strictly greater than the
+ * parent key's column. Per YAML 1.2 §8.1.2, properties before a block
+ * collection must be at indent n+1, where n is the parent key column.
+ */
+function validatePropertyContinuationColumn(
+	property: CstNode,
+	state: ComposerState,
+	afterValueSep: boolean,
+	lastValueSepOffset: number,
+	parentKeyColumn: number,
+): void {
+	if (!afterValueSep) return;
+	if (parentKeyColumn < 0) return;
+	// On the same line as `:` is always OK.
+	if (lastValueSepOffset >= 0 && sameLine(state.text, lastValueSepOffset, property.offset)) {
+		return;
+	}
+	const col = lineCol(state.text, property.offset).column;
+	if (col <= parentKeyColumn) {
+		const lc = lineCol(state.text, property.offset);
+		state.errors.push(
+			new YamlErrorDetail({
+				code: "InvalidIndentation",
+				message: "Property (anchor or tag) must be indented past the parent key",
+				offset: property.offset,
+				length: property.length,
+				line: lc.line,
+				column: lc.column,
+			}),
+		);
+	}
+}
+
+/**
+ * SY6V: at document level, an anchor or tag must not be followed by a
+ * block-sequence entry indicator "-" on the same line. The anchor/tag
+ * applies to the next node, but a "-" on the same line means the parser
+ * is interpreting it as a sequence start without proper structure.
+ */
+function validateAnchorTagNotFollowedBySeqDashOnSameLine(
+	meta: CstNode,
+	children: readonly CstNode[],
+	idx: number,
+	state: ComposerState,
+): void {
+	for (let j = idx + 1; j < children.length; j++) {
+		const c = children[j];
+		if (!c) continue;
+		if (c.type === "newline") return; // ok — anchor on its own line
+		if (c.type === "whitespace") {
+			// Structural indicators ("-", ":", "?", "---", "...") are typed as
+			// `whitespace` CST nodes at the document/block level — see also
+			// `checkDocumentMarkerSameLine` which tests the same shape for
+			// `---`/`...`. We're looking for a "-" on the same line as the meta.
+			if (c.source === "-" && sameLine(state.text, meta.offset, c.offset)) {
+				const lc = lineCol(state.text, c.offset);
+				state.errors.push(
+					new YamlErrorDetail({
+						code: "UnexpectedToken",
+						message: "Block sequence entry indicator '-' cannot follow an anchor or tag on the same line",
+						offset: c.offset,
+						length: c.length,
+						line: lc.line,
+						column: lc.column,
+					}),
+				);
+				return;
+			}
+			continue;
+		}
+		// Empty placeholder block-seq with length 0 — keep scanning past it.
+		if (c.type === "block-seq" && c.length === 0) continue;
+		return;
+	}
+}
+
+/**
  * Validate that document markers (--- and ...) are not followed by content
  * on the same line. YAML 1.2 §9.1.4/§9.2 require these markers to be on
  * their own line (followed only by whitespace/comments).
@@ -2500,6 +2916,7 @@ function composeBlockSeq(cst: CstNode, state: ComposerState, meta?: NodeMeta): Y
 	const items: YamlNode[] = [];
 	let pendingMeta: NodeMeta = {};
 	let sawEntry = false;
+	const seqIndent = lineIndentColumn(state.text, cst.offset);
 	// Track whether a newline appeared between the most-recent pending tag/anchor
 	// and the upcoming content. When true, the meta belongs to the resulting
 	// collection (outer scope), not to the first key/scalar within it. This
@@ -2664,7 +3081,7 @@ function composeBlockSeq(cst: CstNode, state: ComposerState, meta?: NodeMeta): Y
 			continue;
 		}
 		if (child.type === "flow-map") {
-			const map = composeFlowMap(child, state, hasMeta(pendingMeta) ? pendingMeta : undefined);
+			const map = composeFlowMap(child, state, hasMeta(pendingMeta) ? pendingMeta : undefined, seqIndent);
 			pendingMeta = {};
 			sawEntry = false;
 			items.push(map);
@@ -2673,7 +3090,7 @@ function composeBlockSeq(cst: CstNode, state: ComposerState, meta?: NodeMeta): Y
 			continue;
 		}
 		if (child.type === "flow-seq") {
-			const seq = composeFlowSeq(child, state, hasMeta(pendingMeta) ? pendingMeta : undefined);
+			const seq = composeFlowSeq(child, state, hasMeta(pendingMeta) ? pendingMeta : undefined, seqIndent);
 			pendingMeta = {};
 			sawEntry = false;
 			items.push(seq);
@@ -2725,7 +3142,7 @@ function composeBlockSeq(cst: CstNode, state: ComposerState, meta?: NodeMeta): Y
 // Compose flow map
 // ---------------------------------------------------------------------------
 
-function composeFlowMap(cst: CstNode, state: ComposerState, meta?: NodeMeta): YamlMap {
+function composeFlowMap(cst: CstNode, state: ComposerState, meta?: NodeMeta, parentBlockColumn?: number): YamlMap {
 	const children = cst.children ?? [];
 	const pairs: YamlPair[] = [];
 
@@ -2745,6 +3162,10 @@ function composeFlowMap(cst: CstNode, state: ComposerState, meta?: NodeMeta): Ya
 			}),
 		);
 	}
+
+	// 9C9N, VJP3/00: continuation lines of multi-line flow content must be
+	// indented past the parent block context.
+	validateFlowContentIndent(cst, state, parentBlockColumn);
 
 	// Validate that flow mapping entries are separated by commas.
 	// Between consecutive content tokens (scalars, nested collections),
@@ -2971,9 +3392,13 @@ function flattenFlowChildren(children: readonly CstNode[], state: ComposerState)
 // Compose flow seq
 // ---------------------------------------------------------------------------
 
-function composeFlowSeq(cst: CstNode, state: ComposerState, meta?: NodeMeta): YamlSeq {
+function composeFlowSeq(cst: CstNode, state: ComposerState, meta?: NodeMeta, parentBlockColumn?: number): YamlSeq {
 	const children = cst.children ?? [];
 	const items: YamlNode[] = [];
+
+	// 9C9N, VJP3/00: continuation lines of multi-line flow content must be
+	// indented past the parent block context.
+	validateFlowContentIndent(cst, state, parentBlockColumn);
 
 	// Validate flow separators (commas between entries)
 	validateFlowSeparators(children, state, "[", "]");
@@ -3263,12 +3688,17 @@ function composeDocument(
 		// Anchor/tag metadata. When a newline preceded the new meta and meta was
 		// already set, the existing meta belongs to the outer container.
 		if (child.type === "anchor") {
+			// SY6V: anchor followed by a block-seq entry indicator "-" on the
+			// SAME line is invalid. Anchors must be followed by a node, not a
+			// new block-seq indicator on the same line.
+			validateAnchorTagNotFollowedBySeqDashOnSameLine(child, children, i, state);
 			commitMetaAcrossNewline();
 			meta.anchor = getAnchorName(child, state.text);
 			i++;
 			continue;
 		}
 		if (child.type === "tag") {
+			validateAnchorTagNotFollowedBySeqDashOnSameLine(child, children, i, state);
 			commitMetaAcrossNewline();
 			meta.tag = child.source;
 			i++;
@@ -3392,6 +3822,11 @@ function composeDocument(
 							);
 						}
 					}
+				} else {
+					// BS4K: a single-line plain scalar followed by another plain
+					// scalar (with a comment in between, breaking multi-line merge)
+					// is invalid trailing content.
+					checkTrailingContentAfterDocValue(children, nextIdx, state, false);
 				}
 				i = nextIdx;
 				continue;
@@ -3779,6 +4214,13 @@ function validateCrossDocumentDirectives(cstNodes: readonly CstNode[], state: Co
 		if (!cst) continue;
 		const children = cst.children ?? [];
 
+		// QLJ7: directives are local to a single document. Subsequent
+		// documents do not inherit %TAG handles from earlier documents,
+		// so a `!handle!` reference here without a local %TAG is unresolved.
+		// Run this for every doc >= 1 — even docs that DO declare directives
+		// can reference handles those directives didn't define.
+		validateTagHandlesInDocument(cst, state);
+
 		// Check if this document has directives
 		const hasDirectives = children.some((c) => c.type === "directive");
 		if (!hasDirectives) continue;
@@ -3818,6 +4260,58 @@ function validateCrossDocumentDirectives(cstNodes: readonly CstNode[], state: Co
 					break;
 				}
 			}
+		}
+	}
+}
+
+/**
+ * QLJ7: validate that any `!handle!suffix` tag reference in this document
+ * is declared by a `%TAG` directive in the SAME document. %TAG directives
+ * are local to a single document and do not leak across `---` boundaries.
+ * The `!!` shorthand and the primary `!` handle are always available.
+ */
+function validateTagHandlesInDocument(docCst: CstNode, state: ComposerState): void {
+	const children = docCst.children ?? [];
+	// Build local tagMap from %TAG directives in this doc.
+	const localHandles = new Set<string>();
+	for (const child of children) {
+		if (child.type !== "directive") continue;
+		const directive = parseDirective(child.source);
+		if (directive && directive.name === "TAG" && directive.parameters.length >= 2) {
+			const handle = directive.parameters[0];
+			if (handle) localHandles.add(handle);
+		}
+	}
+	// Walk the doc's CST nodes for `tag` children and validate references.
+	const stack: CstNode[] = [docCst];
+	while (stack.length > 0) {
+		const node = stack.pop();
+		if (!node) continue;
+		if (node.type === "tag") {
+			const src = node.source;
+			// Verbatim tags `!<...>` and `!!`-prefixed (default secondary handle)
+			// and bare `!` are always valid.
+			if (src.startsWith("!<") || src.startsWith("!!") || src === "!") continue;
+			const m = src.match(/^(![\w-]*!)/);
+			if (m) {
+				const handle = m[1];
+				if (handle && !localHandles.has(handle)) {
+					const lc = lineCol(state.text, node.offset);
+					state.errors.push(
+						new YamlErrorDetail({
+							code: "UnresolvedTag",
+							message: `Tag handle ${handle} is not declared in this document`,
+							offset: node.offset,
+							length: node.length,
+							line: lc.line,
+							column: lc.column,
+						}),
+					);
+				}
+			}
+		}
+		if (node.children) {
+			for (const c of node.children) stack.push(c);
 		}
 	}
 }
@@ -3974,7 +4468,9 @@ export function parseDocument(
 					e.code === "UnexpectedToken" ||
 					e.code === "InvalidDirective" ||
 					e.code === "MalformedFlowCollection" ||
-					e.code === "InvalidIndentation",
+					e.code === "InvalidIndentation" ||
+					e.code === "TabIndentation" ||
+					e.code === "UnresolvedTag",
 			);
 			if (fatalErrors.length > 0) {
 				return Effect.fail(new YamlComposerError({ errors: fatalErrors, text }));
@@ -4049,7 +4545,9 @@ export function parseAllDocuments(
 						e.code === "AliasCountExceeded" ||
 						e.code === "UnexpectedToken" ||
 						e.code === "InvalidDirective" ||
-						e.code === "InvalidIndentation",
+						e.code === "InvalidIndentation" ||
+						e.code === "TabIndentation" ||
+						e.code === "UnresolvedTag",
 				);
 				if (fatal.length > 0) fatalErrors.push(...fatal);
 			}


### PR DESCRIPTION
## Summary

- Adds composer-side structural validations that reject 11 categories of malformed YAML the spec says are invalid but were previously accepted.
- Raw yaml-test-suite compliance rises from **98.27% → 98.89%** (2397/2424 assertions). The XFAIL skip map is now empty (0 entries).
- Public API and error channel are unchanged. Existing `Effect.catchTag("YamlComposerError", ...)` handlers see no shape difference, just more cases that now correctly surface.

## Newly rejected inputs

| Fixture | Pattern |
| ------- | ------- |
| SY6V | `&anchor - x` (anchor followed by `-` on same line) |
| G9HC, H7J7 | anchor or tag at column ≤ parent key in value position |
| 4HVU | `- entry` at indent shallower than its sibling sequence |
| 9C9N, VJP3/00 | multi-line flow content not indented past parent block |
| C2SP | multi-line flow collection used as implicit mapping key |
| QB6E | multi-line quoted scalar at wrong indent |
| BS4K | plain scalar continued across a comment |
| 4JVG | two anchor declarations on one scalar |
| Y79Y/009 | tab as block indent after a value indicator |
| 5LLU, S98Z, W9L4 | block-scalar leading empties more indented than first content line |
| QLJ7 | `!handle!` reference where `%TAG` was only declared in an earlier document |

## New helpers in `src/utils/composer.ts`

- `validateAnchorTagNotFollowedBySeqDashOnSameLine`
- `validatePropertyContinuationColumn`
- `precededByExplicitKeyMarker` (keeps `KK5P`-style `? - a` valid)
- `validateFlowContentIndent` + new `parentBlockColumn` parameter on `composeFlowMap`/`composeFlowSeq`
- `validateQuotedScalarContinuationIndent`
- `validateNoDoubleAnchorOnScalar`
- `validateNoTabAfterContinuationValueSep` (emits `TabIndentation`)
- `validateBlockScalarLeadingEmpties`
- `validateTagHandlesInDocument` (emits `UnresolvedTag`)
- shared `lineIndentColumn(text, offset)` (replaces `lineCol(text, offset).column` for parent-key indent so keys with leading metadata like `!<tag> foo:` anchor to col 0)

`checkMultilineImplicitKeys` is extended to flag multi-line flow-style `YamlMap`/`YamlSeq` keys (C2SP). Trailing-content detection is extended to fire when the standalone-scalar branch produces `partsCount === 1` and trailing content follows (BS4K).

Fatal-error filters: `parseDocument` now treats `TabIndentation` and `UnresolvedTag` as fatal; `parseAllDocuments` treats `UnresolvedTag` as fatal.

## Docs

- `.claude/design/yaml-effect/parsing.md`, `errors.md`, `compliance-testing.md` updated with the new validations and current compliance numbers.
- `README.md` note block rewritten — the resolved-leniency framing replaced with the actual remaining gap (canonical-stringifier output cases, all in `SKIP_ASSERTIONS`).
- `docs/errors.md` and `docs/parsing.md` add `InvalidIndentation` and `UnexpectedToken` to the composer error-codes tables.

## Test plan

- [x] `pnpm run test` — unit + filtered compliance suites pass (1149 + 1198).
- [x] `pnpm run test:compliance-raw` — 2397/2424 passing (98.89%); the 27 remaining failures are all `should match canonical output` assertions already in `SKIP_ASSERTIONS`.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm run lint` — clean.

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>