### PR TITLE
perf(composer): index newlines once per document for lineCol lookups

### DIFF
--- a/.changeset/silent-cows-refuse.md
+++ b/.changeset/silent-cows-refuse.md
@@ -1,0 +1,7 @@
+---
+"yaml-effect": patch
+---
+
+## Performance
+
+* Fixed O(n²) composition on large documents by precomputing a line-start offset index once per document and binary-searching it, instead of rescanning from offset 0 for every AST node's line/column lookup. A 468KB `pnpm-lock.yaml` now parses in ~1.9s, down from ~12.5s. No API or behavioral changes — line/column results are unchanged.

--- a/.claude/design/yaml-effect/parsing.md
+++ b/.claude/design/yaml-effect/parsing.md
@@ -364,6 +364,16 @@ structure. State and helpers:
   or an empty block-seq placeholder (length 0) or a `?`-only block-map
   sentinel. Used by the stray-dash check to allow KK5P-style explicit
   keys (`? - a`) where the parser shape includes such placeholders.
+- `lineCol(text, offset)` (shared helper) -- resolves an offset to
+  line/column via a module-level single-entry memo (`getLineStarts`):
+  line-start offsets are built in one O(n) pass and each call
+  binary-searches for the greatest line start `<= offset`, rebuilding
+  only when a different text string arrives. It previously scanned
+  from character 0 on every call (one per AST node), making
+  composition quadratic on large documents (issue #108). Offsets are
+  clamped to `[0, text.length]`; results are identical to the old
+  scan. `lineIndentColumn` is unaffected -- it only scans back to its
+  own line start.
 - `lineIndentColumn(text, offset)` (shared helper) -- returns the
   column of the first non-whitespace character on the line containing
   `offset`. Used in place of `lineCol(text, offset).column` whenever

--- a/src/utils/composer.ts
+++ b/src/utils/composer.ts
@@ -22,18 +22,39 @@ import { parseCSTAll } from "./parser.js";
 // Line/column computation
 // ---------------------------------------------------------------------------
 
+// Single-entry memo keyed on the text reference: composition issues one
+// lineCol call per AST node against the same document string, so scanning
+// from offset 0 on every call made composition O(nodes × length). The index
+// is rebuilt only when a different text arrives (issue #108).
+let lineStartsText: string | undefined;
+let lineStartsCache: ReadonlyArray<number> = [];
+
+function getLineStarts(text: string): ReadonlyArray<number> {
+	if (lineStartsText === text) return lineStartsCache;
+	const starts = [0];
+	for (let i = 0; i < text.length; i++) {
+		if (text[i] === "\n") starts.push(i + 1);
+	}
+	lineStartsText = text;
+	lineStartsCache = starts;
+	return starts;
+}
+
 function lineCol(text: string, offset: number): { line: number; column: number } {
-	let line = 0;
-	let column = 0;
-	for (let i = 0; i < offset && i < text.length; i++) {
-		if (text[i] === "\n") {
-			line++;
-			column = 0;
+	const starts = getLineStarts(text);
+	const pos = Math.min(Math.max(offset, 0), text.length);
+	// Binary search for the greatest line start <= pos.
+	let lo = 0;
+	let hi = starts.length - 1;
+	while (lo < hi) {
+		const mid = (lo + hi + 1) >> 1;
+		if (starts[mid] <= pos) {
+			lo = mid;
 		} else {
-			column++;
+			hi = mid - 1;
 		}
 	}
-	return { line, column };
+	return { line: lo, column: pos - starts[lo] };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the O(n²) composition hot path reported in #108. `lineCol()` in `src/utils/composer.ts` scanned the document from character 0 on every call — one call per AST node — so composing large documents was quadratic in document size (75% of total CPU when parsing a 468KB `pnpm-lock.yaml`).

The line-start offsets are now built in a single O(n) pass, memoized per text reference (`getLineStarts`), and each lookup binary-searches the index for the greatest line start ≤ offset. Offsets are clamped to `[0, text.length]`, so line/column results are byte-identical to the old scan. No API or behavioral changes.

## Results

| Input | Before | After |
| --- | --- | --- |
| 468KB `pnpm-lock.yaml` (the file from #108) | ~12.5s | ~1.9s |
| 283KB `pnpm-lock.yaml` | ~0.6s | ~0.6s |

## Verification

- Full suite: 2375 passed, 0 failed (includes all 1226 yaml-test-suite compliance assertions)
- `pnpm run typecheck` clean
- Patch changeset included (`.changeset/silent-cows-refuse.md`)

Closes #108

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved line and column position lookup performance, especially for larger text inputs or frequent cursor/offset checks.
  * Made position calculations more robust by safely clamping offsets within valid text bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->